### PR TITLE
Add CPU-only unit tests for SUNDMRG and SUNRepresentations

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,10 @@
+using Test
+using SUNDMRG
+using SUNRepresentations
+
+@testset "SUNDMRG CPU-only pure tests" begin
+    include("test_init.jl")
+    include("test_suncalc.jl")
+    include("test_sparsevec2.jl")
+    include("test_tables_small.jl")
+end

--- a/test/test_init.jl
+++ b/test/test_init.jl
@@ -1,0 +1,23 @@
+@testset "Model/lattice/engine initialization" begin
+    model = SU(2)HeisenbergModel()
+    @test model isa SUNDMRG.HeisenbergModelSU{2}
+
+    sq = SquareLattice(4, 2)
+    @test sq.Lx == 4
+    @test sq.Ly == 2
+
+    hc = HoneycombLattice(4, 2, :ZC)
+    @test hc.Lx == 4
+    @test hc.Ly == 2
+    @test hc.BC == :ZC
+
+    @test_throws AssertionError HoneycombLattice(4, 3, :ZC)
+    @test_throws AssertionError HoneycombLattice(4, 2, :PBC)
+
+    left = SUNDMRG.Block(2, Tuple{Int, Int}[], [SUNDMRG.trivialirrep(Val(2))], [1], [1], Dict(:H => [zeros(1, 1)]))
+    right = SUNDMRG.Block(3, Tuple{Int, Int}[], [SUNDMRG.trivialirrep(Val(2))], [1], [1], Dict(:H => [zeros(1, 1)]))
+
+    @test SUNDMRG.graphic(left, right) == "==**---"
+    @test SUNDMRG.graphic(left, right; sys_label = :r) == "---**=="
+    @test_throws ArgumentError SUNDMRG.graphic(left, right; sys_label = :x)
+end

--- a/test/test_sparsevec2.jl
+++ b/test/test_sparsevec2.jl
@@ -1,0 +1,19 @@
+@testset "SparseVector2 operations" begin
+    x = SUNDMRG.sparsevec2(Int[3, 1], [2.0, 1.0], 5)
+    y = SUNDMRG.sparsevec2(Int[1, 2, 3], [4.0, -1.0, -2.0], 5)
+
+    @test x[1] == 1.0
+    @test x[2] == 0.0
+    @test x[3] == 2.0
+
+    z = x + y
+    @test z[1] == 5.0
+    @test z[2] == -1.0
+    @test z[3] == 0.0
+
+    @test SUNDMRG.dot(x, y) == 2.0 * -2.0 + 1.0 * 4.0
+
+    a = 2.5 * x
+    @test a[1] == 2.5
+    @test a[3] == 5.0
+end

--- a/test/test_suncalc.jl
+++ b/test/test_suncalc.jl
@@ -1,0 +1,31 @@
+@testset "Pure SU helper functions" begin
+    irr0 = SUNDMRG.irrep(3, 0)
+    irr1 = SUNDMRG.irrep(3, 1)
+    @test irr0 == [1, 1, 1]
+    @test irr1 == [2, 1, 1]
+
+    λ = SUNDMRG.irreplist(2, 3)
+    @test first(weight.(λ)) == (0, 0)
+    @test last(weight.(λ)) == (3, 0)
+    @test length(λ) == 4
+
+    trivial = SUNDMRG.trivialirrep(Val(2))
+    funda = SUNDMRG.fundamentalirrep(Val(2))
+    adj = SUNDMRG.adjointirrep(Val(2))
+    @test weight(trivial) == (0, 0)
+    @test weight(funda) == (1, 0)
+    @test weight(adj) == (2, 0)
+
+    β = [trivial, funda, adj]
+    OM = SUNDMRG.OM_matrix(β, β, trivial)
+    @test size(OM) == (3, 3)
+    @test OM[1, 1] == 1
+
+    # SU(2) consistency helpers
+    w3 = SUNDMRG.wigner3ν(funda, funda, adj)
+    @test size(w3) == (1, 1)
+
+    w6 = SUNDMRG.wigner6ν(funda, funda, adj, funda, funda, adj)
+    w6r = SUNDMRG.wigner6νrev(funda, funda, adj, funda, funda, adj)
+    @test size(w6) == reverse(size(w6r))
+end

--- a/test/test_tables_small.jl
+++ b/test/test_tables_small.jl
@@ -1,0 +1,19 @@
+@testset "Small SU(2) table-related helpers" begin
+    trivial = SUNDMRG.trivialirrep(Val(2))
+    funda = SUNDMRG.fundamentalirrep(Val(2))
+    adj = SUNDMRG.adjointirrep(Val(2))
+
+    c3 = SUNDMRG._3ν(funda, funda, adj)
+    @test size(c3) == (1, 1)
+
+    c6 = SUNDMRG._6ν(funda, funda, adj, funda, funda, adj)
+    c6r = SUNDMRG._6νrev(funda, funda, adj, funda, funda, adj)
+    @test size(c6) == (1, 1, 1, 1)
+    @test size(c6r) == (1, 1, 1, 1)
+
+    c9 = SUNDMRG._9ν(trivial, funda, funda, funda, trivial, funda, trivial, funda, trivial)
+    @test size(c9) == (1, 1, 1, 1, 1, 1)
+
+    # On-the-fly table helper matches direct 3ν exchange matrix.
+    @test SUNDMRG.on_the_fly_calc6((funda, funda, adj)) == SUNDMRG.wigner3ν(funda, funda, adj)
+end


### PR DESCRIPTION
### Motivation
- Provide a lightweight CPU-only test suite to validate core pure-Julia functionality of the package and related representation helpers.
- Catch regressions in representation/table helpers, sparse vector utilities, lattice/model initialization, and the `graphic` utility for `Block` objects. 
- Enable automated verification of SU helper routines and small table lookups used throughout the codebase. 

### Description
- Add a test harness `test/runtests.jl` that groups and runs focused CPU-only tests from four files. 
- Add `test/test_init.jl` to cover `SU(2)` model creation, `SquareLattice` and `HoneycombLattice` construction, `Block` setup, and `SUNDMRG.graphic` semantics. 
- Add `test/test_suncalc.jl` to validate `irrep`, `irreplist`, `trivialirrep/fundamentalirrep/adjointirrep`, `OM_matrix`, and Wigner helper functions `wigner3ν`/`wigner6ν`/`wigner6νrev`. 
- Add `test/test_sparsevec2.jl` and `test/test_tables_small.jl` to check `sparsevec2` arithmetic and small-table helpers `_3ν`, `_6ν`, `_6νrev`, `_9ν`, and `on_the_fly_calc6`. 

### Testing
- Ran the new test suite via `julia --project -e 'include("test/runtests.jl")'` to exercise the added test files. 
- All added tests executed and completed successfully. 
- The tests specifically exercise the pure-Julia parts of `SUNDMRG` and `SUNRepresentations` and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3bf0ac5c83308944b6acd9a8cbd0)