### PR TITLE
Refactor type annotations and linear-algebra helpers; add CPU-only unit tests and README test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,19 @@ The value has to become zero or a negligibly small value in the last few sweeps.
 * SUNRepresentations.jl 0.1.2-
 * MPI.jl: We strongly recommend to use Open MPI.
 
+## Testing
+
+A lightweight CPU-only unit test suite is available for pure/helper functionality
+(e.g., initialization helpers, SU helper routines, sparse vector operations, and
+small table helper checks).
+
+Run:
+```julia
+julia --project -e 'using Pkg; Pkg.test()'
+```
+
 ## TODO
 
-* Type piracy in lanczos.jl
 * Hybrid parallelization
 * Supporting the triangular lattice
 * Thick-restart Lanczos

--- a/src/block.jl
+++ b/src/block.jl
@@ -1,7 +1,7 @@
 struct Block{Nc}
     length::Int
     bonds::Vector{Tuple{Int, Int}}
-    β_list::Vector{SUNIrrep{Nc}}
+    β_list::Vector{<:SUNIrrep{Nc}}
     mβ_list_old::Vector{Int}
     mβ_list::Vector{Int}
     scalar_dict::Dict{Symbol, Vector{Matrix{Float64}}}
@@ -12,9 +12,9 @@ abstract type EnlargedBlock{Nc} end
 struct EnlargedBlockCPU{Nc} <: EnlargedBlock{Nc}
     length::Int
     bonds::Vector{Tuple{Int, Int}}
-    α_list::Vector{SUNIrrep{Nc}}
+    α_list::Vector{<:SUNIrrep{Nc}}
     mα_list::Vector{Int}
-    β_list::Vector{SUNIrrep{Nc}}
+    β_list::Vector{<:SUNIrrep{Nc}}
     mβ_list::Vector{Int}
     mαβ::Matrix{Int}
     scalar_dict::Dict{Symbol, Vector{Matrix{Float64}}}
@@ -24,9 +24,9 @@ end
 struct EnlargedBlockGPU{Nc} <: EnlargedBlock{Nc}
     length::Int
     bonds::Vector{Tuple{Int, Int}}
-    α_list::Vector{SUNIrrep{Nc}}
+    α_list::Vector{<:SUNIrrep{Nc}}
     mα_list::Vector{Int}
-    β_list::Vector{SUNIrrep{Nc}}
+    β_list::Vector{<:SUNIrrep{Nc}}
     mβ_list::Vector{Int}
     mαβ::Matrix{Int}
     scalar_dict::Dict{Symbol, Vector{CuMatrix{Float64}}}
@@ -173,9 +173,9 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
         end
     else
         if engine <: GPUEngine
-            block_enl = EnlargedBlockGPU{Nc}(block.length + 1, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], SUNIrrep{Nc}[], Int[], zeros(Int, 0, 0), Dict{Symbol, Vector{CuMatrix{Float64}}}(:H => Hnew), tensor_dict)
+            block_enl = EnlargedBlockGPU{Nc}(block.length + 1, Tuple{Int, Int}[], typeof(trivialirrep(Val(Nc)))[], Int[], typeof(trivialirrep(Val(Nc)))[], Int[], zeros(Int, 0, 0), Dict{Symbol, Vector{CuMatrix{Float64}}}(:H => Hnew), tensor_dict)
         else
-            block_enl = EnlargedBlockCPU{Nc}(block.length + 1, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], SUNIrrep{Nc}[], Int[], zeros(Int, 0, 0), Dict{Symbol, Vector{Matrix{Float64}}}(:H => Hnew), tensor_dict)
+            block_enl = EnlargedBlockCPU{Nc}(block.length + 1, Tuple{Int, Int}[], typeof(trivialirrep(Val(Nc)))[], Int[], typeof(trivialirrep(Val(Nc)))[], Int[], zeros(Int, 0, 0), Dict{Symbol, Vector{Matrix{Float64}}}(:H => Hnew), tensor_dict)
         end
     end
 

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -107,9 +107,10 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         end
     end
 
-    γ_list = SUNIrrep{Nc}[]
+    γ_type = typeof(trivialirrep(Val(Nc)))
+    γ_list = γ_type[]
     for h in ((1 : Nc) .% Nc)
-        push!(γ_list, SUNIrrep(ntuple(i -> 0 + (i <= h), Val(Nc))))
+        push!(γ_list, SUNIrrep{Nc}(ntuple(i -> 0 + (i <= h), Val(Nc))))
     end
 
     MPI.Init_thread(MPI.THREAD_FUNNELED)
@@ -207,11 +208,11 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         println("#")
     else
         dirid = 0
-        blockL = Block(0, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
+        blockL = Block(0, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
         blockL_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
 
         if !mirror
-            blockR = Block(0, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
+            blockR = Block(0, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
             blockR_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
         end
     end
@@ -359,7 +360,7 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
 
                         env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
                     else
-                        env_block = Block(L - sys_blocks[i].length - 1, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
+                        env_block = Block(L - sys_blocks[i].length - 1, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                         env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
                         env_trmats[i] = Matrix{Float64}[]
                     end
@@ -388,7 +389,7 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
 
                     env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
                 else
-                    env_block = Block(L - sys_blocks[i].length - 2, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
+                    env_block = Block(L - sys_blocks[i].length - 2, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                     env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
                     env_trmats[i] = Matrix{Float64}[]
                 end
@@ -473,7 +474,7 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
 
         env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
     else
-        env_block = Block(L - sys_block.length - 1, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
+        env_block = Block(L - sys_block.length - 1, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
         env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
         env_trmat = Matrix{Float64}[]
     end
@@ -515,7 +516,7 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
 
                 env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
             else
-                env_block = Block(L - sys_block.length - 2, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
+                env_block = Block(L - sys_block.length - 2, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                 env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
                 env_trmat = Matrix{Float64}[]
             end

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -1,19 +1,19 @@
 const tol_wavefunction = 1e-13
 const tol_Lanczos = 1e-13
 
-MyMatrix = Union{Matrix{Vector{Matrix{Float64}}}, Matrix{Vector{CuMatrix{Float64, Mem.DeviceBuffer}}}, Matrix{Vector{CuMatrix{Float64, Mem.HostBuffer}}}, Matrix{Vector{CuMatrix{Float64, Mem.UnifiedBuffer}}}} # I am not sure whether this is a good hack
+MyMatrix = Matrix{<:Vector{<:AbstractMatrix{Float64}}}
 
-function LinearAlgebra.dot(x::MyMatrix, y::MyMatrix)
+function mydot(x::MyMatrix, y::MyMatrix)
     s = 0.0
     for (IX, IY) in zip(eachindex(x), eachindex(y))
         for (JX, JY) in zip(eachindex(x[IX]), eachindex(y[IY]))
-            s += dot(x[IX][JX], y[IY][JY])
+            s += LinearAlgebra.dot(x[IX][JX], y[IY][JY])
         end
     end
     s
 end
 
-function LinearAlgebra.axpy!(α, x::MyMatrix, y::MyMatrix)
+function myaxpy!(α, x::MyMatrix, y::MyMatrix)
     for (IY, IX) in zip(eachindex(y), eachindex(x))
         for (JY, JX) in zip(eachindex(y[IY]), eachindex(x[IX]))
             @. y[IY][JY] += α * x[IX][JX]
@@ -22,7 +22,7 @@ function LinearAlgebra.axpy!(α, x::MyMatrix, y::MyMatrix)
     y
 end
 
-function LinearAlgebra.axpby!(α, x::MyMatrix, β, y::MyMatrix)
+function myaxpby!(α, x::MyMatrix, β, y::MyMatrix)
     for (IX, IY) in zip(eachindex(x), eachindex(y))
         for (JX, JY) in zip(eachindex(x[IX]), eachindex(y[IY]))
             @. y[IY][JY] = α * x[IX][JX] + β * y[IY][JY]
@@ -31,7 +31,7 @@ function LinearAlgebra.axpby!(α, x::MyMatrix, β, y::MyMatrix)
     y
 end
 
-function LinearAlgebra.rmul!(A::MyMatrix, b::Number)
+function myrmul!(A::MyMatrix, b::Number)
     for I in eachindex(A)
         for J in eachindex(A[I])
             A[I][J] .*= b
@@ -40,7 +40,7 @@ function LinearAlgebra.rmul!(A::MyMatrix, b::Number)
     A
 end
 
-function LinearAlgebra.rdiv!(A::MyMatrix, b::Number)
+function myrdiv!(A::MyMatrix, b::Number)
     for I in eachindex(A)
         for J in eachindex(A[I])
             A[I][J] ./= b
@@ -49,7 +49,7 @@ function LinearAlgebra.rdiv!(A::MyMatrix, b::Number)
     A
 end
 
-function Base.copyto!(dest::MyMatrix, src::MyMatrix)
+function mycopyto!(dest::MyMatrix, src::MyMatrix)
     for (IX, IY) in zip(eachindex(dest), eachindex(src))
         for (JX, JY) in zip(eachindex(dest[IX]), eachindex(src[IY]))
             dest[IX][JX] .= src[IY][JY]
@@ -69,28 +69,28 @@ function CG!(A!::Function, val, x, Ax, buffer1, buffer2, comm, rank)
     Ap = buffer2
     for i in 1 : 100
         valshift = val - 1e-8
-        axpby!(1.0 + valshift, x, -1.0, r)
-        copyto!(p, r)
-        normold = MPI.Allreduce(dot(r, r), MPI.SUM, comm)
+        myaxpby!(1.0 + valshift, x, -1.0, r)
+        mycopyto!(p, r)
+        normold = MPI.Allreduce(mydot(r, r), MPI.SUM, comm)
         j = 1
         while true
             A!(Ap, p)
-            axpy!(-valshift, p, Ap)
-            α = normold / MPI.Allreduce(dot(p, Ap), MPI.SUM, comm)
-            axpy!(α, p, x)
-            axpy!(-α, Ap, r)
-            normnew = MPI.Allreduce(dot(r, r), MPI.SUM, comm)
+            myaxpy!(-valshift, p, Ap)
+            α = normold / MPI.Allreduce(mydot(p, Ap), MPI.SUM, comm)
+            myaxpy!(α, p, x)
+            myaxpy!(-α, Ap, r)
+            normnew = MPI.Allreduce(mydot(r, r), MPI.SUM, comm)
             if j == 10 || normnew < 1e-8
                 break
             end
             β = normnew / normold
-            axpby!(1.0, r, β, p)
+            myaxpby!(1.0, r, β, p)
             normold = normnew
             j += 1
         end
-        rdiv!(x, sqrt(MPI.Allreduce(dot(x, x), MPI.SUM, comm)))
+        myrdiv!(x, sqrt(MPI.Allreduce(mydot(x, x), MPI.SUM, comm)))
         A!(r, x)
-        valnew = MPI.Allreduce(dot(x, r), MPI.SUM, comm)
+        valnew = MPI.Allreduce(mydot(x, r), MPI.SUM, comm)
         if abs((valnew - val) / valnew) < tol_wavefunction
             break
         end
@@ -110,7 +110,7 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
             ketkm1[I][J] .= 0.0
         end
     end
-    rdiv!(initial, sqrt(MPI.Allreduce(dot(initial, initial), MPI.SUM, comm)))
+    myrdiv!(initial, sqrt(MPI.Allreduce(mydot(initial, initial), MPI.SUM, comm)))
     ketk = deepcopy(initial)
     ketk1 = deepcopy(ketk)
     β = 0.0
@@ -126,7 +126,7 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
     k = 1
     while true
         A!(ketk1, ketk)
-        α = MPI.Allreduce(dot(ketk, ketk1), MPI.SUM, comm)
+        α = MPI.Allreduce(mydot(ketk, ketk1), MPI.SUM, comm)
         push!(αlist, α)
         if k >= position
             if rank == 0
@@ -138,9 +138,9 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
             end
             vold = vals[position]
         end
-        axpy!(-β, ketkm1, ketk1)
-        axpy!(-α, ketk, ketk1)
-        β = sqrt(MPI.Allreduce(dot(ketk1, ketk1), MPI.SUM, comm))
+        myaxpy!(-β, ketkm1, ketk1)
+        myaxpy!(-α, ketk, ketk1)
+        β = sqrt(MPI.Allreduce(mydot(ketk1, ketk1), MPI.SUM, comm))
         if β == 0.0
             if rank == 0
                 vals, vecs = LAPACK.stev!('V', copy(αlist), copy(βlist))
@@ -148,9 +148,9 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
             vals = MPI.bcast(vals, 0, comm)::Vector{Float64}
             break
         end
-        rdiv!(ketk1, β)
-        copyto!(ketkm1, ketk)
-        copyto!(ketk, ketk1)
+        myrdiv!(ketk1, β)
+        mycopyto!(ketkm1, ketk)
+        mycopyto!(ketk, ketk1)
         push!(βlist, β)
         if alg == :fast
             push!(ketk_list, map(x -> Array.(x), ketk))
@@ -164,34 +164,34 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
             ketkm1[I][J] .= 0.0
         end
     end
-    copyto!(ketk, initial)
+    mycopyto!(ketk, initial)
     β = 0.0
     position = min(position, size(vecs, 2))
-    rmul!(initial, vecs[1, position])
+    myrmul!(initial, vecs[1, position])
     for k in 1 : size(vecs, 1) - 1
         if alg == :slow
             A!(ketk1, ketk)
             α = αlist[k]
-            axpy!(-β, ketkm1, ketk1)
-            axpy!(-α, ketk, ketk1)
+            myaxpy!(-β, ketkm1, ketk1)
+            myaxpy!(-α, ketk, ketk1)
             β = βlist[k]
-            rdiv!(ketk1, β)
-            copyto!(ketkm1, ketk)
-            copyto!(ketk, ketk1)
-            axpy!(vecs[k + 1, position], ketk, initial)
+            myrdiv!(ketk1, β)
+            mycopyto!(ketkm1, ketk)
+            mycopyto!(ketk, ketk1)
+            myaxpy!(vecs[k + 1, position], ketk, initial)
         else
             if engine <: GPUEngine
-                axpy!(vecs[k + 1, position], [CuArray.(ketk_list[k][i, j]) for i in 1 : m, j in 1 : n], initial)
+                myaxpy!(vecs[k + 1, position], [CuArray.(ketk_list[k][i, j]) for i in 1 : m, j in 1 : n], initial)
             else
-                axpy!(vecs[k + 1, position], ketk_list[k], initial)
+                myaxpy!(vecs[k + 1, position], ketk_list[k], initial)
             end
         end
     end
-    rdiv!(initial, sqrt(MPI.Allreduce(dot(initial, initial), MPI.SUM, comm)))
+    myrdiv!(initial, sqrt(MPI.Allreduce(mydot(initial, initial), MPI.SUM, comm)))
     A!(ketk, initial)
-    val = MPI.Allreduce(dot(initial, ketk), MPI.SUM, comm)
+    val = MPI.Allreduce(mydot(initial, ketk), MPI.SUM, comm)
     val2 = val ^ 2
-    var = MPI.Allreduce(dot(ketk, ketk), MPI.SUM, comm)
+    var = MPI.Allreduce(mydot(ketk, ketk), MPI.SUM, comm)
     if abs((val - vals[position]) / val) < tol_wavefunction && abs((var - val2) / val2) < tol_wavefunction
         rtnval = val
     else

--- a/src/measurement.jl
+++ b/src/measurement.jl
@@ -126,7 +126,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     end
                 end
 
-                sisj = MPI.Reduce(dot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
+                sisj = MPI.Reduce(mydot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
 
                 if rank == 0
                     SiSj[bond] = sisj
@@ -228,7 +228,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     end
                 end
 
-                sisj = MPI.Reduce(dot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
+                sisj = MPI.Reduce(mydot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
 
                 if rank == 0
                     SiSj[bond] = sisj
@@ -329,7 +329,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                         end
                     end
 
-                    sisj = MPI.Reduce(dot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
+                    sisj = MPI.Reduce(mydot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
 
                     if rank == 0
                         SiSj[bond] = sisj
@@ -482,7 +482,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     end
                 end
 
-                sisj = MPI.Reduce(dot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
+                sisj = MPI.Reduce(mydot(Ψ0, SiSjΨ0), MPI.SUM, 0, comm)
 
                 if rank == 0
                     SiSj[bond] = sisj

--- a/src/step.jl
+++ b/src/step.jl
@@ -104,10 +104,10 @@ newblock, newtensor_dict, newblock_enl, trerr, energy, Ψ0, trmat, ee, es, Sj = 
 a single step for DMRG
 """
 function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_dict, env_tensor_dict, sys_enl::EnlargedBlock{Nc}, env_enl::EnlargedBlock{Nc}, Ly, m, α, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, ::Val{env_calc}; Ψ0_guess = nothing, ES_max = -Inf, correlation = :none, margin = 0, lattice = :square, Sj = Matrix{Vector{Matrix{Float64}}}(undef, 0, 0), alg = :slow, noisy = true) where {Nc, env_calc}
-    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
-    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
-    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
-    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
     sys_ms = MPI.bcast(sys_enl.mβ_list, 0, comm)::Vector{Int}
     env_ms = MPI.bcast(env_enl.mβ_list, 0, comm)::Vector{Int}
     sys_mαβ = MPI.bcast(sys_enl.mαβ, 0, comm)::Matrix{Int}
@@ -708,7 +708,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
         if rank == 0
             push!(newblock, Block(block_enl.length, block_enl.bonds, block_enl.β_list, block_enl.mβ_list, msnew, Dict{Symbol, Vector{Matrix{Float64}}}(:H => Hnew)))
         else
-            push!(newblock, Block(block_enl.length, Tuple{Int, Int}[], SUNIrrep{Nc}[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}()))
+            push!(newblock, Block(block_enl.length, Tuple{Int, Int}[], typeof(trivialirrep(Val(Nc)))[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}()))
         end
 
         push!(newtensor_dict, tensor_dict)
@@ -726,9 +726,9 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
     end
 
     if !isnothing(Ψ0_guess)
-        nume = MPI.Reduce(dot(Ψ0_guess, Ψ0), MPI.SUM, 0, comm)
-        den1 = MPI.Reduce(dot(Ψ0_guess, Ψ0_guess), MPI.SUM, 0, comm)
-        den2 = MPI.Reduce(dot(Ψ0, Ψ0), MPI.SUM, 0, comm)
+        nume = MPI.Reduce(mydot(Ψ0_guess, Ψ0), MPI.SUM, 0, comm)
+        den1 = MPI.Reduce(mydot(Ψ0_guess, Ψ0_guess), MPI.SUM, 0, comm)
+        den2 = MPI.Reduce(mydot(Ψ0, Ψ0), MPI.SUM, 0, comm)
         if noisy && rank == 0
             println("overlap |<ψ_guess|ψ>| = ", abs(nume) / sqrt(den1 * den2))
         end

--- a/src/suncalc.jl
+++ b/src/suncalc.jl
@@ -34,7 +34,7 @@ function irreplist(Nc, widthmax)
     rtn = SUNIrrep{Nc}[]
     elem = irrep(Nc, index)
     while elem[1] <= widthmax
-        push!(rtn, SUNIrrep(Tuple(elem)))
+        push!(rtn, SUNIrrep{Nc}(Tuple(elem)))
         index += 1
         elem .= irrep(Nc, index)
     end
@@ -69,8 +69,8 @@ end
 trivialirrep(Val(Nc))
 returns the trivial irrep
 """
-function trivialirrep(val)
-    SUNIrrep(ntuple(i -> 0, val))
+function trivialirrep(::Val{Nc}) where Nc
+    SUNIrrep{Nc}(ntuple(i -> 0, Val(Nc)))
 end
 
 """
@@ -78,15 +78,15 @@ adjointirrep(Val(Nc))
 returns the adjoint irrep
 """
 function adjointirrep(::Val{Nc}) where Nc
-    SUNIrrep(ntuple(i -> 1 + (i == 1) - (i == Nc), Val(Nc)))
+    SUNIrrep{Nc}(ntuple(i -> 1 + (i == 1) - (i == Nc), Val(Nc)))
 end
 
 """
 fundamentalirrep(Val(Nc))
 returns the fundamental irrep
 """
-function fundamentalirrep(val)
-    SUNIrrep(ntuple(i -> 0 + (i == 1), val))
+function fundamentalirrep(::Val{Nc}) where Nc
+    SUNIrrep{Nc}(ntuple(i -> 0 + (i == 1), Val(Nc)))
 end
 
 """

--- a/src/table3nu.jl
+++ b/src/table3nu.jl
@@ -60,7 +60,7 @@ function make_table3nu(Nc, widthmax)
         if iseven(Nc) && isodd(h)
             continue
         end
-        γ = SUNIrrep(ntuple(i -> 0 + (i <= h), Val(Nc)))
+        γ = SUNIrrep{Nc}(ntuple(i -> 0 + (i <= h), Val(Nc)))
         for (i, α1) in enumerate(λ), (j, β1) in enumerate(λ)
             OM = outer_multiplicity(α1, β1, γ)
             if OM > 0

--- a/src/table4.jl
+++ b/src/table4.jl
@@ -28,7 +28,7 @@ function make_table4(Nc, widthmax)
         if iseven(Nc) && isodd(h)
             continue
         end
-        γ = SUNIrrep(ntuple(i -> 0 + (i <= h), Val(Nc)))
+        γ = SUNIrrep{Nc}(ntuple(i -> 0 + (i <= h), Val(Nc)))
         OM = OM_matrix(λ, γ)
         for (i, α1) in Iterators.filter(x -> any(OM[x[1], :] .> 0), enumerate(λ))
             α2dict = directproduct(α1, adjoint)

--- a/src/tablecalc.jl
+++ b/src/tablecalc.jl
@@ -233,7 +233,7 @@ function table_9ν(Nc, widthmax, table4, table_3ν)
         if iseven(Nc) && isodd(h)
             continue
         end
-        γ = SUNIrrep(ntuple(i -> 0 + (i <= h), Val(Nc)))
+        γ = SUNIrrep{Nc}(ntuple(i -> 0 + (i <= h), Val(Nc)))
         T = OM_matrix(λ, γ) .> 0
         for (i, α1) in Iterators.filter(x -> any(T[x[1], :]), enumerate(λ))
             for (j, β1) in Iterators.filter(x -> T[i, x[1]], enumerate(λ))
@@ -250,7 +250,7 @@ function table_9ν(Nc, widthmax, table4, table_3ν)
         if iseven(Nc) && isodd(h)
             continue
         end
-        γ = SUNIrrep(ntuple(i -> 0 + (i <= h), Val(Nc)))
+        γ = SUNIrrep{Nc}(ntuple(i -> 0 + (i <= h), Val(Nc)))
         T = OM_matrix(λ, γ) .> 0
         for (i, α1) in Iterators.filter(x -> any(T[x[1], :]), enumerate(λ))
             α2dict = directproduct(α1, adjoint)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -9,10 +9,10 @@ function eig_prediction(Ψ0, sys_label, sys_enl::EnlargedBlock{Nc}, env_enl::Enl
     env_mαβ = MPI.bcast(env_enl.mαβ, 0, comm)::Matrix{Int}
     cum_sys_mαβ = vcat(zeros(Int, 1, size(sys_mαβ, 2)), cumsum(sys_mαβ, dims = 1))
     cum_env_mαβ = vcat(zeros(Int, 1, size(env_mαβ, 2)), cumsum(env_mαβ, dims = 1))
-    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
-    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
-    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
-    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
     OM = OM_matrix(sys_βs, env_αs, γirrep)
     sys_mα = MPI.bcast(sys_enl.mα_list, 0, comm)::Vector{Int}
     sys_mβ = MPI.bcast(sys_enl.mβ_list, 0, comm)::Vector{Int}
@@ -119,8 +119,8 @@ end
 function _wavefunction_reverse(Ψ0, sys_label, sys, env, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Nc)
     γirrep = γ_list[mod1(sys.length + env.length, Nc)]
 
-    sys_βs = MPI.bcast(sys.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
-    env_βs = MPI.bcast(env.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    sys_βs = MPI.bcast(sys.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    env_βs = MPI.bcast(env.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
 
     if engine <: GPUEngine
         Ψ0_new = [[CUDA.zeros(Float64, size(Ψ0[i, j][J], 2), size(Ψ0[i, j][J], 1)) for J in 1 : length(Ψ0[i, j])] for j in 1 : size(Ψ0, 2), i in 1 : size(Ψ0, 1)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,9 @@
+using Test
+using SUNDMRG
+
+@testset "SUNDMRG CPU-only pure tests" begin
+    include("test_init.jl")
+    include("test_suncalc.jl")
+    include("test_sparsevec2.jl")
+    include("test_tables_small.jl")
+end

--- a/test/test_init.jl
+++ b/test/test_init.jl
@@ -1,0 +1,23 @@
+@testset "Model/lattice/engine initialization" begin
+    model = SUNDMRG.SU(2) * SUNDMRG.HeisenbergModel()
+    @test model isa SUNDMRG.HeisenbergModelSU{2}
+
+    sq = SUNDMRG.SquareLattice(4, 2)
+    @test sq.Lx == 4
+    @test sq.Ly == 2
+
+    hc = SUNDMRG.HoneycombLattice(4, 2, :ZC)
+    @test hc.Lx == 4
+    @test hc.Ly == 2
+    @test hc.BC == :ZC
+
+    @test_throws AssertionError SUNDMRG.HoneycombLattice(4, 3, :ZC)
+    @test_throws AssertionError SUNDMRG.HoneycombLattice(4, 2, :PBC)
+
+    left = (length = 2,)
+    right = (length = 3,)
+
+    @test SUNDMRG.graphic(left, right) == "==**---"
+    @test SUNDMRG.graphic(left, right; sys_label = :r) == "---**=="
+    @test_throws ArgumentError SUNDMRG.graphic(left, right; sys_label = :x)
+end

--- a/test/test_sparsevec2.jl
+++ b/test/test_sparsevec2.jl
@@ -1,0 +1,19 @@
+@testset "SparseVector2 operations" begin
+    x = SUNDMRG.sparsevec2(Int[3, 1], [2.0, 1.0], 5)
+    y = SUNDMRG.sparsevec2(Int[1, 2, 3], [4.0, -1.0, -2.0], 5)
+
+    @test x[1] == 1.0
+    @test x[2] == 0.0
+    @test x[3] == 2.0
+
+    z = x + y
+    @test z[1] == 5.0
+    @test z[2] == -1.0
+    @test z[3] == 0.0
+
+    @test SUNDMRG.dot(x, y) == 2.0 * -2.0 + 1.0 * 4.0
+
+    a = 2.5 * x
+    @test a[1] == 2.5
+    @test a[3] == 5.0
+end

--- a/test/test_suncalc.jl
+++ b/test/test_suncalc.jl
@@ -1,0 +1,33 @@
+using SUNRepresentations: weight
+
+@testset "Pure SU helper functions" begin
+    irr0 = SUNDMRG.irrep(3, 0)
+    irr1 = SUNDMRG.irrep(3, 1)
+    @test irr0 == [0, 0, 0]
+    @test irr1 == [1, 0, 0]
+
+    λ = SUNDMRG.irreplist(2, 3)
+    @test first(weight.(λ)) == (0, 0)
+    @test last(weight.(λ)) == (3, 0)
+    @test length(λ) == 4
+
+    trivial = SUNDMRG.trivialirrep(Val(2))
+    funda = SUNDMRG.fundamentalirrep(Val(2))
+    adj = SUNDMRG.adjointirrep(Val(2))
+    @test weight(trivial) == (0, 0)
+    @test weight(funda) == (1, 0)
+    @test weight(adj) == (2, 0)
+
+    β = [trivial, funda, adj]
+    OM = SUNDMRG.OM_matrix(β, β, trivial)
+    @test size(OM) == (3, 3)
+    @test OM[1, 1] == 1
+
+    # SU(2) consistency helpers
+    w3 = SUNDMRG.wigner3ν(funda, funda, adj)
+    @test size(w3) == (1, 1)
+
+    w6 = SUNDMRG.wigner6ν(funda, funda, adj, funda, funda, adj)
+    w6r = SUNDMRG.wigner6νrev(funda, funda, adj, funda, funda, adj)
+    @test size(w6) == reverse(size(w6r))
+end

--- a/test/test_tables_small.jl
+++ b/test/test_tables_small.jl
@@ -1,0 +1,19 @@
+@testset "Small SU(2) table-related helpers" begin
+    trivial = SUNDMRG.trivialirrep(Val(2))
+    funda = SUNDMRG.fundamentalirrep(Val(2))
+    adj = SUNDMRG.adjointirrep(Val(2))
+
+    c3 = SUNDMRG._3ν(funda, funda, adj)
+    @test size(c3) == (1, 1)
+
+    c6 = SUNDMRG._6ν(funda, funda, adj, funda, funda, adj)
+    c6r = SUNDMRG._6νrev(funda, funda, adj, funda, funda, adj)
+    @test size(c6) == (1, 1, 1, 1)
+    @test size(c6r) == (1, 1, 1, 1)
+
+    c9 = SUNDMRG._9ν(trivial, funda, funda, funda, trivial, funda, trivial, funda, trivial)
+    @test size(c9) == (1, 1, 1, 1, 1, 1)
+
+    # On-the-fly table helper matches direct 3ν exchange matrix.
+    @test SUNDMRG.on_the_fly_calc6((funda, funda, adj)) == SUNDMRG.wigner3ν(funda, funda, adj)
+end


### PR DESCRIPTION
### Motivation

- Improve type stability and correctness for SUNIrrep-typed fields by widening annotations and using `SUNIrrep{Nc}` constructors with explicit `Nc` parameters.
- Replace ad-hoc Union type for big wavefunction matrices with a compact parametric alias and avoid overloading base `LinearAlgebra`/`Base` functions by providing local vector/matrix helpers used throughout Lanczos and measurement code.
- Add a lightweight CPU-only unit test suite to prevent regressions on pure/helper functionality and document how to run tests in `README.md`.

### Description

- Tightened and generalized irrep-related types: many fields now use `Vector{<:SUNIrrep{Nc}}` or `typeof(trivialirrep(Val(Nc)))[]` and irrep constructors were changed to `SUNIrrep{Nc}(...)` and helper functions changed to signatures like `trivialirrep(::Val{Nc})`, `fundamentalirrep(::Val{Nc})`, and `adjointirrep(::Val{Nc})` to propagate `Nc` explicitly.
- Replaced the previous `MyMatrix` union with `MyMatrix = Matrix{<:Vector{<:AbstractMatrix{Float64}}}` and introduced local linear-algebra helper functions `mydot`, `myaxpy!`, `myaxpby!`, `myrmul!`, `myrdiv!`, `mycopyto!` used in place of the prior `dot`/`axpy!`/`copyto!` overloads in `lanczos.jl`, and propagated calls to these helpers in `measurement.jl`, `step.jl`, and other routines.
- Updated multiple callsites to use the new irrep typing and helper names across `src/*` files (`block.jl`, `finite.jl`, `lanczos.jl`, `measurement.jl`, `step.jl`, `suncalc.jl`, `table3nu.jl`, `table4.jl`, `tablecalc.jl`, `tools.jl`) to maintain compatibility and avoid type-piracy issues.
- Added a small CPU-only test suite under `test/` (`runtests.jl`, `test_init.jl`, `test_suncalc.jl`, `test_sparsevec2.jl`, `test_tables_small.jl`) and a `Testing` section to `README.md` describing how to run `Pkg.test()`.

### Testing

- Ran the new CPU-only test suite with `julia --project -e 'using Pkg; Pkg.test()'`, executing testsets `SUNDMRG CPU-only pure tests`, `Model/lattice/engine initialization`, `Pure SU helper functions`, `SparseVector2 operations`, and `Small SU(2) table-related helpers`, and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3bf0ac5c83308944b6acd9a8cbd0)