### PR TITLE
test: add more CPU-only coverage for pure SU and sparse helpers

### DIFF
--- a/test/test_sparsevec2.jl
+++ b/test/test_sparsevec2.jl
@@ -17,3 +17,18 @@
     @test a[1] == 2.5
     @test a[3] == 5.0
 end
+
+
+@testset "SparseVector2 constructors/utilities" begin
+    z = SUNDMRG.spzeros2(Float64, Int, 7)
+    @test z.n == 7
+    @test isempty(z.nzind)
+    @test isempty(z.nzval)
+
+    unsorted = SUNDMRG.sparsevec2(Int[5, 2, 4], [50.0, 20.0, 40.0], 6)
+    @test unsorted.nzind == [2, 4, 5]
+    @test unsorted.nzval == [20.0, 40.0, 50.0]
+
+    SUNDMRG.lmul!(0.5, unsorted)
+    @test unsorted.nzval == [10.0, 20.0, 25.0]
+end

--- a/test/test_suncalc.jl
+++ b/test/test_suncalc.jl
@@ -31,3 +31,16 @@ using SUNRepresentations: weight
     w6r = SUNDMRG.wigner6νrev(funda, funda, adj, funda, funda, adj)
     @test size(w6) == reverse(size(w6r))
 end
+
+
+@testset "Additional irrep/OM consistency" begin
+    λ0 = SUNDMRG.irreplist(3, 0)
+    @test length(λ0) == 1
+    @test weight(only(λ0)) == (0, 0, 0)
+
+    trivial3 = SUNDMRG.trivialirrep(Val(3))
+    funda3 = SUNDMRG.fundamentalirrep(Val(3))
+    OMself = SUNDMRG.OM_matrix([trivial3, funda3], trivial3)
+    @test size(OMself) == (2, 2)
+    @test OMself[1, 1] == 1
+end


### PR DESCRIPTION
### Motivation
- Improve maintainability by adding small, deterministic CPU-only unit tests for pure helper functions and data constructors without touching DMRG algorithmic code or requiring MPI/CUDA/MAGMA.
- Keep the change minimal and reviewable by only extending existing test files to cover low-risk functions suitable for CI unit tests.

### Description
- Add a tiny SU(3) sanity check to `test/test_suncalc.jl` that exercises `irreplist(Nc, widthmax=0)` and the 2-argument overload `OM_matrix(βlist, γ)` to validate shape/value behavior for a trivial example.
- Extend `test/test_sparsevec2.jl` with constructor/utility tests for `spzeros2`, verify `sparsevec2` correctly sorts unsorted indices/values, and test in-place scaling via `lmul!`.
- No changes were made to core algorithmic code paths, MPI/CUDA/MAGMA imports, or large-memory routines; only test files were modified and `test/runtests.jl` already includes the updated test files.

### Testing
- Verified repository structure and test files (`rg --files`, `find`) and inspected the updated tests (`sed`/`nl`) to ensure the new test blocks are present and well-formed.
- Confirmed the Git changes were staged and committed with the message `test: expand CPU-only pure helper coverage` (commit made successfully).
- Attempted to run the Julia test suite with `julia --project -e 'using Pkg; Pkg.test()'`, but this environment lacks Julia (`julia: command not found`) so automated test execution could not be performed here.
- Static validations (file diffs and status) succeeded and the added tests are CPU-only and avoid MPI/CUDA/MAGMA execution paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb54440fa08330ba9432642203613b)