### PR TITLE
Refactor _run_DMRG into modular phases and fix mirror/trmat handling

### DIFF
--- a/src/finite.jl
+++ b/src/finite.jl
@@ -86,7 +86,7 @@ function run_DMRG(model::HeisenbergModelSU{Nc}, lat::HoneycombLattice, m_warmup:
     end
 end
 
-function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sweep_list, m_cooldown, engine; target = 0, widthmax = 0, tables = nothing, fileio = false, scratch = ".", ES_max = 20.0, tol_energy = 1e-5, tol_EE = 1e-3, correlation = :none, margin = 0, alg = :slow) where Nc
+function _init_runtime_and_engine(engine, lattice, Lx, Ly, Nc)
     @assert Nc >= 2
 
     on_the_fly = Nc == 2
@@ -94,9 +94,6 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
 
     @assert iseven(Lx)
     @assert lattice == :square || lattice == :honeycombZC
-    @assert correlation == :none || correlation == :nn || correlation == :chain
-    @assert alg == :slow || alg == :fast
-
     if on_the_fly
         @assert (Lx * Ly) % Nc == 0
     else
@@ -128,6 +125,10 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
 
     N = Lx * Ly
     signfactor = iseven(Nc) ? -1.0 : 1.0
+    return on_the_fly, mirror, γ_type, γ_list, comm, rank, Ncpu, N, signfactor
+end
+
+function _init_state(engine, lattice, Lx, Ly, Nc, target, m_warmup, widthmax, tables, fileio, scratch, on_the_fly, mirror, γ_type, comm, rank, Ncpu, signfactor)
     m_list = Tuple{Int, Float64}[]
     errors = Float64[]
     energies = Float64[]
@@ -175,6 +176,10 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
             else
                 trmatR = [diagm([1.0])]
             end
+        else
+            blockR = blockL
+            blockR_tensor_dict = blockL_tensor_dict
+            trmatR = trmatL
         end
 
         if mirror
@@ -214,12 +219,19 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         if !mirror
             blockR = Block(0, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
             blockR_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
+            trmatR = Matrix{Float64}[]
+        else
+            blockR = blockL
+            blockR_tensor_dict = blockL_tensor_dict
+            trmatR = Matrix{Float64}[]
         end
     end
 
     blockL_enl = enlarge_block(blockL, blockL_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
     if !mirror
         blockR_enl = enlarge_block(blockR, blockR_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
+    else
+        blockR_enl = blockL_enl
     end
 
     if engine <: GPUEngine
@@ -236,6 +248,10 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         end
     end
 
+    return m_list, errors, energies, EEs, EE, ES, SiSj, block_table, tensor_table, trmat_table, dirid, blockL, blockL_tensor_dict, blockR, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ
+end
+
+function _warmup_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, trmat_table, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
     while blockL.length < Ly
         if rank == 0
             if mirror
@@ -292,6 +308,10 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         end
     end
 
+    return blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, ES
+end
+
+function _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, tensor_table, trmat_table, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
     L = 2blockL.length
 
     if mirror
@@ -447,6 +467,10 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         end
     end
 
+    return L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, ES
+end
+
+function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, block_table, tensor_table, trmat_table, Ly, L, Nc, m_sweep_list, m_cooldown, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, fileio, scratch, dirid, lattice, alg, correlation, margin, ES_max, tol_energy, tol_EE)
     Ψ0 = Ψ[1]
 
     sys_label, env_label = :l, :r
@@ -582,7 +606,11 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         end
     end
 
-    if rank == 0 && fileio
+    return ES, EE
+end
+
+function _finalize_runtime!(engine, fileio, scratch, dirid, comm)
+    if fileio
         rm("$scratch/temp$dirid"; recursive = true)
     end
 
@@ -591,6 +619,24 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
     end
 
     MPI.Finalize()
+
+end
+
+function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sweep_list, m_cooldown, engine; target = 0, widthmax = 0, tables = nothing, fileio = false, scratch = ".", ES_max = 20.0, tol_energy = 1e-5, tol_EE = 1e-3, correlation = :none, margin = 0, alg = :slow) where Nc
+    @assert correlation == :none || correlation == :nn || correlation == :chain
+    @assert alg == :slow || alg == :fast
+
+    on_the_fly, mirror, γ_type, γ_list, comm, rank, Ncpu, N, signfactor = _init_runtime_and_engine(engine, lattice, Lx, Ly, Nc)
+
+    m_list, errors, energies, EEs, EE, ES, SiSj, block_table, tensor_table, trmat_table, dirid, blockL, blockL_tensor_dict, blockR, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ = _init_state(engine, lattice, Lx, Ly, Nc, target, m_warmup, widthmax, tables, fileio, scratch, on_the_fly, mirror, γ_type, comm, rank, Ncpu, signfactor)
+
+    blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, ES = _warmup_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, trmat_table, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
+
+    L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, ES = _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, tensor_table, trmat_table, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
+
+    ES, EE = _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, block_table, tensor_table, trmat_table, Ly, L, Nc, m_sweep_list, m_cooldown, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, fileio, scratch, dirid, lattice, alg, correlation, margin, ES_max, tol_energy, tol_EE)
+
+    _finalize_runtime!(engine, rank == 0 && fileio, scratch, dirid, comm)
 
     ESrtn = Dict{NTuple{Nc, Int}, Vector{Float64}}()
     for (key, value) in ES


### PR DESCRIPTION
### Motivation

- Improve readability and maintainability by splitting the large `_run_DMRG` routine into smaller, focused helper routines.  
- Ensure correct initialization/finalization for MPI and GPU engines and fix mirror-related block/transfer-matrix handling.  

### Description

- Split the original `_run_DMRG` into helper functions: `_init_runtime_and_engine`, `_init_state`, `_warmup_phase!`, `_growth_phase!`, `_sweep_phase!`, and `_finalize_runtime!`.  
- Restored and localized assertions for `correlation` and `alg` and moved runtime/GPU/MPI initialization into `_init_runtime_and_engine`.  
- Centralized initial state construction in `_init_state` and fixed mirror cases by reusing `blockL`/`trmatL` for `blockR` when appropriate and ensuring consistent `trmatR` initialization for non-root ranks.  
- Each phase now returns updated state explicitly (for example `_warmup_phase!` returns updated blocks, tensors, `Ψ`, and `ES`), and `_run_DMRG` composes the flow from these helpers.  
- Added `_finalize_runtime!` to perform file cleanup, GPU `magma_finalize()`, and `MPI.Finalize()`.  
- Minor refactors: clearer return tuples, consistent handling of CPU/GPU arrays, and small code reorganizations (e.g. `ESrtn` construction and SU(2) `SiSj` scaling preserved).  

### Testing

- Ran the package test suite with `Pkg.test()`; tests completed successfully.  
- Executed a short smoke DMRG run for a small SU(2) lattice to verify warmup/growth/sweep phases and MPI/GPU init/finalize behavior, and the run completed as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeae27a97883308476c808899b65bc)