### PR TITLE
Introduce engine_utils and centralize engine-specific allocations/conversions

### DIFF
--- a/src/SUNDMRG.jl
+++ b/src/SUNDMRG.jl
@@ -18,6 +18,7 @@ export DMRGOutput, run_DMRG, make_table, make_table3nu, make_table4, HeisenbergM
 
 include("suncalc.jl")
 include("lanczos.jl")
+include("engine_utils.jl")
 include("block.jl")
 include("measurement.jl")
 include("step.jl")

--- a/src/block.jl
+++ b/src/block.jl
@@ -94,11 +94,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
         end
     end
 
-    if engine <: GPUEngine
-        tensor_dict[zy] = [CuArray.(Stemp[i, j]) for i in 1 : lenβ, j in 1 : lenβ]
-    else
-        tensor_dict[zy] = Stemp
-    end
+    tensor_dict[zy] = [to_engine_array.(Ref(engine), Stemp[i, j]) for i in 1 : lenβ, j in 1 : lenβ]
 
     if rank == 0
         y1 = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(block.length, 2Ly))
@@ -114,11 +110,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
         fac2 = (Nc ^ 2 - 1) / sqrt(Nc) * signfactor
         bonds = copy(block.bonds)
         Hnew = map(1 : lenβ) do k
-            if engine <: GPUEngine
-                rtn = any(αβmatrix[:, k]) ? cat(CuArray.(block.scalar_dict[:H][αβmatrix[:, k]])...; dims = (1, 2)) : CUDA.zeros(Float64, 0, 0)
-            else
-                rtn = any(αβmatrix[:, k]) ? cat(block.scalar_dict[:H][αβmatrix[:, k]]...; dims = (1, 2)) : zeros(0, 0)
-            end
+            rtn = any(αβmatrix[:, k]) ? cat(to_engine_array.(Ref(engine), block.scalar_dict[:H][αβmatrix[:, k]])...; dims = (1, 2)) : zeros_like_engine(engine, Float64, 0, 0)
             for z in zlist
                 for i in 1 : lenα
                     if αβmatrix[i, k]
@@ -154,11 +146,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
             end
         end
     else
-        if engine <: GPUEngine
-            Hnew = [CuMatrix{Float64}(undef, m, m) for m in ms]
-        else
-            Hnew = [Matrix{Float64}(undef, m, m) for m in ms]
-        end
+        Hnew = [engine_matrix_type(engine)(undef, m, m) for m in ms]
     end
 
     for k in 1 : lenβ
@@ -245,24 +233,12 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
                         end
                     end
 
-                    if engine <: GPUEngine
-                        Snew = [CuArray.(Stemp[i, j]) for i in 1 : lenβ, j in 1 : lenβ]
-                    else
-                        Snew = Stemp
-                    end
+                    Snew = [to_engine_array.(Ref(engine), Stemp[i, j]) for i in 1 : lenβ, j in 1 : lenβ]
 
                     if fileio
-                        if engine <: GPUEngine
-                            env_trmat = CuArray.(load_object("$scratch/temp$dirid/trmat_$(env_label)_$z.jld2")::Vector{Matrix{Float64}})
-                        else
-                            env_trmat = load_object("$scratch/temp$dirid/trmat_$(env_label)_$z.jld2")::Vector{Matrix{Float64}}
-                        end
+                        env_trmat = to_engine_array.(Ref(engine), load_object("$scratch/temp$dirid/trmat_$(env_label)_$z.jld2")::Vector{Matrix{Float64}})
                     else
-                        if engine <: GPUEngine
-                            env_trmat = CuArray.(trmat_table[env_label, z])
-                        else
-                            env_trmat = trmat_table[env_label, z]
-                        end
+                        env_trmat = to_engine_array.(Ref(engine), trmat_table[env_label, z])
                     end
 
                     lennew = length(env_trmat)
@@ -272,9 +248,9 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
                     for x in z + 1 : env.length
                         if engine <: GPUEngine
                             if fileio
-                                jldsave("$scratch/temp$dirid/tensor_$(env_label)_$(x - 1)_$y.jld2"; env_tensor_dict = [Array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew])
+                                jldsave("$scratch/temp$dirid/tensor_$(env_label)_$(x - 1)_$y.jld2"; env_tensor_dict = [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew])
                             else
-                                tensor_table[env_label, x - 1, y] = [Array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew]
+                                tensor_table[env_label, x - 1, y] = [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew]
                             end
                         else
                             if fileio
@@ -300,11 +276,7 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
                         Snew = map([(i, j) for i in 1 : lenβ, j in 1 : lenβ]) do (i, j)
                             o1 = get(dp[j], βs[i], 0)
                             map(1 : o1) do τ1
-                                if engine <: GPUEngine
-                                    rtn = CUDA.zeros(Float64, ms[i], ms[j])
-                                else
-                                    rtn = zeros(ms[i], ms[j])
-                                end
+                                rtn = zeros_like_engine(engine, Float64, ms[i], ms[j])
                                 for ki in findall(αβmatrix[:, i]), kj in findall(αβmatrix[:, j])
                                     if haskey(dp2[kj], αs[ki])
                                         coeff = on_the_fly ? on_the_fly_calc1(Nc, (αs[kj], βs[j], αs[ki], βs[i])) : tables[1][αs[kj], βs[j], αs[ki], βs[i]]
@@ -318,17 +290,9 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
                         end
 
                         if fileio
-                            if engine <: GPUEngine
-                                env_trmat = CuArray.(load_object("$scratch/temp$dirid/trmat_$(env_label)_$x.jld2")::Vector{Matrix{Float64}})
-                            else
-                                env_trmat = load_object("$scratch/temp$dirid/trmat_$(env_label)_$x.jld2")::Vector{Matrix{Float64}}
-                            end
+                            env_trmat = to_engine_array.(Ref(engine), load_object("$scratch/temp$dirid/trmat_$(env_label)_$x.jld2")::Vector{Matrix{Float64}})
                         else
-                            if engine <: GPUEngine
-                                env_trmat = CuArray.(trmat_table[env_label, x])
-                            else
-                                env_trmat = trmat_table[env_label, x]
-                            end
+                            env_trmat = to_engine_array.(Ref(engine), trmat_table[env_label, x])
                         end
         
                         lennew = length(env_trmat)
@@ -337,7 +301,7 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
                     end
 
                     if engine <: GPUEngine
-                        spin = [Array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew]
+                        spin = [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew]
                     else
                         spin = Sold
                     end

--- a/src/engine_utils.jl
+++ b/src/engine_utils.jl
@@ -1,0 +1,51 @@
+"""
+    zeros_like_engine(engine, T, dims...)
+
+Allocate a zero-filled array with element type `T` and shape `dims`, matching the backend implied by `engine`.
+"""
+function zeros_like_engine(engine, T, dims...)
+    if engine <: GPUEngine
+        CUDA.zeros(T, dims...)
+    else
+        zeros(T, dims...)
+    end
+end
+
+"""
+    to_engine_array(engine, x)
+
+Convert `x` to an engine-native array representation.
+"""
+function to_engine_array(engine, x)
+    if engine <: GPUEngine
+        CuArray(x)
+    else
+        x
+    end
+end
+
+"""
+    to_host_array(x)
+
+Convert an engine array back to a host `Array` when needed.
+"""
+function to_host_array(x)
+    if x isa CuArray
+        Array(x)
+    else
+        x
+    end
+end
+
+"""
+    engine_matrix_type(engine)
+
+Return the concrete matrix type used by the selected engine for `Float64` data.
+"""
+function engine_matrix_type(engine)
+    if engine <: GPUEngine
+        CuMatrix{Float64}
+    else
+        Matrix{Float64}
+    end
+end

--- a/src/measurement.jl
+++ b/src/measurement.jl
@@ -28,11 +28,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     Sx = sys_tensor_dict[x]
                     # end
                 end
-                if engine <: GPUEngine
-                    Stemp = [[CUDA.zeros(Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                else
-                    Stemp = [[zeros(sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                end
+                Stemp = [[zeros_like_engine(engine, Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
                 for e in sys_enlarge
                     @. Stemp[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sx[e.ki, e.kj][e.τ2]
                 end
@@ -67,11 +63,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                 SiSjΨ0 = deepcopy(Ψ0)
 
                 if rank == 0
-                    if engine <: GPUEngine
-                        Ψtemp = [[CUDA.zeros(Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                    else
-                        Ψtemp = [[zeros(env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                    end
+                    Ψtemp = [[zeros_like_engine(engine, Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
                 end
 
                 for s in superblock_H2
@@ -80,11 +72,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     if rank == root1
                         temp3 = Ψ0[s.env_in, s.sys_in][s.om1]
                     else
-                        if engine <: GPUEngine
-                            temp3 = CuMatrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                        else
-                            temp3 = Matrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                        end
+                        temp3 = engine_matrix_type(engine)(undef, s.env_in_size, s.sys_in_size)
                     end
 
                     if engine <: GPUEngine
@@ -156,11 +144,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                         Sx2 = env_tensor_dict[x]
                         # end
                     end
-                    if engine <: GPUEngine
-                        env_S = [[CUDA.zeros(Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                    else
-                        env_S = [[zeros(env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                    end
+                    env_S = [[zeros_like_engine(engine, Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
                     for e in env_enlarge
                         @. env_S[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sx2[e.ki, e.kj][e.τ2]
                     end
@@ -169,11 +153,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                 SiSjΨ0 = deepcopy(Ψ0)
 
                 if rank == 0
-                    if engine <: GPUEngine
-                        Ψtemp = [[CUDA.zeros(Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                    else
-                        Ψtemp = [[zeros(env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                    end
+                    Ψtemp = [[zeros_like_engine(engine, Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
                 end
 
                 for s in superblock_H2
@@ -182,11 +162,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     if rank == root1
                         temp3 = Ψ0[s.env_in, s.sys_in][s.om1]
                     else
-                        if engine <: GPUEngine
-                            temp3 = CuMatrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                        else
-                            temp3 = Matrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                        end
+                        temp3 = engine_matrix_type(engine)(undef, s.env_in_size, s.sys_in_size)
                     end
 
                     if engine <: GPUEngine
@@ -257,11 +233,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                             Sy = env_tensor_dict[y]
                             # end
                         end
-                        if engine <: GPUEngine
-                            env_S = [[CUDA.zeros(Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                        else
-                            env_S = [[zeros(env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                        end
+                        env_S = [[zeros_like_engine(engine, Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
                         for e in env_enlarge
                             @. env_S[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sy[e.ki, e.kj][e.τ2]
                         end
@@ -270,11 +242,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     SiSjΨ0 = deepcopy(Ψ0)
 
                     if rank == 0
-                        if engine <: GPUEngine
-                            Ψtemp = [[CUDA.zeros(Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                        else
-                            Ψtemp = [[zeros(env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                        end
+                        Ψtemp = [[zeros_like_engine(engine, Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
                     end
 
                     for s in superblock_H2
@@ -283,11 +251,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                         if rank == root1
                             temp3 = Ψ0[s.env_in, s.sys_in][s.om1]
                         else
-                            if engine <: GPUEngine
-                                temp3 = CuMatrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                            else
-                                temp3 = Matrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                            end
+                            temp3 = engine_matrix_type(engine)(undef, s.env_in_size, s.sys_in_size)
                         end
 
                         if engine <: GPUEngine
@@ -346,30 +310,22 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
             if !isempty(Sj) && (sys_label == :l && sys.length == 0)
                 len = length(env_αs)
                 if engine <: GPUEngine
-                    Sj2 = [CuArray.(Sj[i, j]) for i in 1 : len, j in 1 : len]
+                    Sj2 = [to_engine_array.(Ref(engine), Sj[i, j]) for i in 1 : len, j in 1 : len]
                 else
                     Sj2 = Sj
                 end
-                if engine <: GPUEngine
-                    env_S = [[CUDA.zeros(Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                else
-                    env_S = [[zeros(env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                end
+                env_S = [[zeros_like_engine(engine, Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
                 for e in env_enlarge
                     @. env_S[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sj2[e.ki, e.kj][e.τ2]
                 end
             elseif !isempty(Sj)
                 len = length(sys_αs)
                 if engine <: GPUEngine
-                    Sj2 = [CuArray.(Sj[i, j]) for i in 1 : len, j in 1 : len]
+                    Sj2 = [to_engine_array.(Ref(engine), Sj[i, j]) for i in 1 : len, j in 1 : len]
                 else
                     Sj2 = Sj
                 end
-                if engine <: GPUEngine
-                    sys_S = [[CUDA.zeros(Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                else
-                    sys_S = [[zeros(sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                end
+                sys_S = [[zeros_like_engine(engine, Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
                 for e in sys_enlarge
                     @. sys_S[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sj2[e.ki, e.kj][e.τ2]
                 end
@@ -423,11 +379,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                 SiSjΨ0 = deepcopy(Ψ0)
 
                 if rank == 0
-                    if engine <: GPUEngine
-                        Ψtemp = [[CUDA.zeros(Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                    else
-                        Ψtemp = [[zeros(env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-                    end
+                    Ψtemp = [[zeros_like_engine(engine, Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
                 end
 
                 for s in superblock_H2
@@ -436,11 +388,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                     if rank == root1
                         temp3 = Ψ0[s.env_in, s.sys_in][s.om1]
                     else
-                        if engine <: GPUEngine
-                            temp3 = CuMatrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                        else
-                            temp3 = Matrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-                        end
+                        temp3 = engine_matrix_type(engine)(undef, s.env_in_size, s.sys_in_size)
                     end
 
                     if engine <: GPUEngine

--- a/src/step.jl
+++ b/src/step.jl
@@ -55,22 +55,14 @@ Lanczos_kernel!(Ψout, Ψin, x, y, sys_S, env_S, superblock_H2, OM, sys_len, env
 Function barrier
 """
 function Lanczos_kernel!(Ψout, Ψin, x, y, sys_S, env_S, superblock_H2, OM, sys_len, env_len, sys_ms, env_ms, comm, rank, Ncpu, engine)
-    if engine <: GPUEngine
-        Ψtemp = [[CUDA.zeros(Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-    else
-        Ψtemp = [[zeros(env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
-    end
+    Ψtemp = [[zeros_like_engine(engine, Float64, env_ms[ki], sys_ms[kj]) for J in 1 : OM[kj, ki]] for ki in 1 : env_len, kj in 1 : sys_len]
 
     for s in superblock_H2
         root1 = (s.sys_in + s.env_in - 2) % Ncpu
         if rank == root1
             temp3 = Ψin[s.env_in, s.sys_in][s.om1]
         else
-            if engine <: GPUEngine
-                temp3 = CuMatrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-            else
-                temp3 = Matrix{Float64}(undef, s.env_in_size, s.sys_in_size)
-            end
+            temp3 = engine_matrix_type(engine)(undef, s.env_in_size, s.sys_in_size)
         end
         if engine <: GPUEngine
             CUDA.synchronize()
@@ -270,7 +262,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
 
             if x ∈ first.(bonds_hold)
                 if engine <: GPUEngine
-                    sys_tensor_dict_hold[x] = [CuArray.(Sold[i, j]) for i in 1 : len, j in 1 : len]
+                    sys_tensor_dict_hold[x] = [to_engine_array.(Ref(engine), Sold[i, j]) for i in 1 : len, j in 1 : len]
                 else
                     sys_tensor_dict_hold[x] = Sold
                 end
@@ -350,11 +342,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
             if x == x_conn
                 sys_S = sys_connS
             elseif x > 0
-                if engine <: GPUEngine
-                    sys_S = [[CUDA.zeros(Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                else
-                    sys_S = [[zeros(sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                end
+                sys_S = [[zeros_like_engine(engine, Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
                 for e in sys_enlarge
                     @. sys_S[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * sys_tensor_dict_hold[x][e.ki, e.kj][e.τ2]
                 end
@@ -365,11 +353,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
             if y == y_conn
                 env_S = env_connS
             elseif y > 0
-                if engine <: GPUEngine
-                    env_S = [[CUDA.zeros(Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                else
-                    env_S = [[zeros(env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                end
+                env_S = [[zeros_like_engine(engine, Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
                 for e in env_enlarge
                     @. env_S[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * env_tensor_dict_hold[y][e.ki, e.kj][e.τ2]
                 end
@@ -462,7 +446,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
             for k in 1 : len
                 fac = 1.0 / dimβ[k]
                 if engine <: GPUEngine
-                    ρ = CUDA.zeros(Float64, ms[k], ms[k])
+                    ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
                     for j in 1 : env_len
                         for J in eachindex(Ψ0[j, k])
                             CUBLAS.syrk!('U', 'T', fac, Ψ0[j, k][J], 1.0, ρ)
@@ -470,7 +454,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
                     end
                     CUDA.synchronize()
                 else
-                    ρ = zeros(ms[k], ms[k])
+                    ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
                     for j in 1 : env_len
                         for J in eachindex(Ψ0[j, k])
                             BLAS.syrk!('U', 'T', fac, Ψ0[j, k][J], 1.0, ρ)
@@ -486,7 +470,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
             for k in 1 : len
                 fac = 1.0 / dimβ[k]
                 if engine <: GPUEngine
-                    ρ = CUDA.zeros(Float64, ms[k], ms[k])
+                    ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
                     for j in 1 : sys_len
                         for J in eachindex(Ψ0[k, j])
                             CUBLAS.syrk!('U', 'N', fac, Ψ0[k, j][J], 1.0, ρ)
@@ -494,7 +478,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
                     end
                     CUDA.synchronize()
                 else
-                    ρ = zeros(ms[k], ms[k])
+                    ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
                     for j in 1 : sys_len
                         for J in eachindex(Ψ0[k, j])
                             BLAS.syrk!('U', 'N', fac, Ψ0[k, j][J], 1.0, ρ)
@@ -509,11 +493,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
         end
 
         if rank == 0 && α != 0.0
-            if engine <: GPUEngine
-                Sρs = [CUDA.zeros(Float64, ms[k], ms[k]) for k in 1 : len]
-            else
-                Sρs = [zeros(ms[k], ms[k]) for k in 1 : len]
-            end
+            Sρs = [zeros_like_engine(engine, Float64, ms[k], ms[k]) for k in 1 : len]
             for x in unique(map(x -> x[switch], superblock_bonds))
                 if x == conn
                     if switch == 1
@@ -549,11 +529,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
                             Sx = sys_tensor_dict[x]
                             # end
                         end
-                        if engine <: GPUEngine
-                            Stemp = [[CUDA.zeros(Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                        else
-                            Stemp = [[zeros(sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
-                        end
+                        Stemp = [[zeros_like_engine(engine, Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in 1 : sys_len, j in 1 : sys_len]
                         for e in sys_enlarge
                             @. Stemp[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sx[e.ki, e.kj][e.τ2]
                         end
@@ -568,11 +544,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
                             Sx = env_tensor_dict[x]
                             # end
                         end
-                        if engine <: GPUEngine
-                            Stemp = [[CUDA.zeros(Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                        else
-                            Stemp = [[zeros(env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
-                        end
+                        Stemp = [[zeros_like_engine(engine, Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in 1 : env_len, j in 1 : env_len]
                         for e in env_enlarge
                             @. Stemp[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sx[e.ki, e.kj][e.τ2]
                         end
@@ -611,11 +583,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
                 if rank == 0
                     MPI.Send(ρs[k], balancer[k], k, comm)
                 elseif rank == balancer[k]
-                    if engine <: GPUEngine
-                        ρ = CuMatrix{Float64}(undef, ms[k], ms[k])
-                    else
-                        ρ = Matrix{Float64}(undef, ms[k], ms[k])
-                    end
+                    ρ = engine_matrix_type(engine)(undef, ms[k], ms[k])
                     MPI.Recv!(ρ, 0, k, comm)
                     push!(ρnew, ρ)
                 end
@@ -674,11 +642,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
             Λ = sort!(collect(Iterators.flatten(reverse.(λ))), rev = true)
             λthreshold = m < length(Λ) ? Λ[m + 1] : -Inf
             indices = map(x -> x .> λthreshold, λ)
-            if engine <: GPUEngine
-                transformation_matrix = map(x -> CuArray(x[1][:, x[2]]), zip(ζ, indices))
-            else
-                transformation_matrix = map(x -> x[1][:, x[2]], zip(ζ, indices))
-            end
+            transformation_matrix = map(x -> to_engine_array(engine, x[1][:, x[2]]), zip(ζ, indices))
 
             msnew = map(x -> size(x, 2), transformation_matrix)
             if noisy && switch == 1
@@ -687,11 +651,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
             Hnew = map(x -> Array(x[2]' * (x[1] * x[2])), zip(block_enl.scalar_dict[:H], transformation_matrix))
         else
             push!(ee, 0.0)
-            if engine <: GPUEngine
-                transformation_matrix = [CuMatrix{Float64}(undef, 0, 0)]
-            else
-                transformation_matrix = [Matrix{Float64}(undef, 0, 0)]
-            end
+            transformation_matrix = [engine_matrix_type(engine)(undef, 0, 0)]
         end
         push!(trmat, transformation_matrix)
         push!(es, esi)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -19,11 +19,7 @@ function eig_prediction(Ψ0, sys_label, sys_enl::EnlargedBlock{Nc}, env_enl::Enl
     env_mα = MPI.bcast(env_enl.mα_list, 0, comm)::Vector{Int}
     env_mβ = MPI.bcast(env_enl.mβ_list, 0, comm)::Vector{Int}
 
-    if engine <: GPUEngine
-        Ψ0_guess = [[CUDA.zeros(Float64, mi, mj) for J in 1 : ((j + i - 2) % Ncpu == rank ? OM[j, i] : 0)] for (i, mi) in enumerate(env_mα), (j, mj) in enumerate(sys_mβ)]
-    else
-        Ψ0_guess = [[zeros(mi, mj) for J in 1 : ((j + i - 2) % Ncpu == rank ? OM[j, i] : 0)] for (i, mi) in enumerate(env_mα), (j, mj) in enumerate(sys_mβ)]
-    end
+    Ψ0_guess = [[zeros_like_engine(engine, Float64, mi, mj) for J in 1 : ((j + i - 2) % Ncpu == rank ? OM[j, i] : 0)] for (i, mi) in enumerate(env_mα), (j, mj) in enumerate(sys_mβ)]
     if rank == 0
         for j in 1 : length(sys_αs)
             MPI.bcast(size(sys_trmat[j]), 0, comm)::Tuple{Int, Int}
@@ -34,32 +30,16 @@ function eig_prediction(Ψ0, sys_label, sys_enl::EnlargedBlock{Nc}, env_enl::Enl
             MPI.Bcast!(env_trmat[i], 0, comm)
         end
     else
-        if engine <: GPUEngine
-            sys_trmat = CuMatrix{Float64}[]
-        else
-            sys_trmat = Matrix{Float64}[]
-        end
+        sys_trmat = engine_matrix_type(engine)[]
         for j in 1 : length(sys_αs)
             x, y = MPI.bcast(nothing, 0, comm)::Tuple{Int, Int}
-            if engine <: GPUEngine
-                push!(sys_trmat, CuMatrix{Float64}(undef, x, y))
-            else
-                push!(sys_trmat, Matrix{Float64}(undef, x, y))
-            end
+            push!(sys_trmat, engine_matrix_type(engine)(undef, x, y))
             MPI.Bcast!(sys_trmat[j], 0, comm)
         end
-        if engine <: GPUEngine
-            env_trmat = CuMatrix{Float64}[]
-        else
-            env_trmat = Matrix{Float64}[]
-        end
+        env_trmat = engine_matrix_type(engine)[]
         for i in 1 : length(env_αs)
             x, y = MPI.bcast(nothing, 0, comm)::Tuple{Int, Int}
-            if engine <: GPUEngine
-                push!(env_trmat, CuMatrix{Float64}(undef, x, y))
-            else
-                push!(env_trmat, Matrix{Float64}(undef, x, y))
-            end
+            push!(env_trmat, engine_matrix_type(engine)(undef, x, y))
             MPI.Bcast!(env_trmat[i], 0, comm)
         end
     end
@@ -73,11 +53,7 @@ function eig_prediction(Ψ0, sys_label, sys_enl::EnlargedBlock{Nc}, env_enl::Enl
             if rank == root
                 temp1 = Ψ0[k, j][om2]
             else
-                if engine <: GPUEngine
-                    temp1 = CuMatrix{Float64}(undef, env_mβ[k], sys_mα[j])
-                else
-                    temp1 = Matrix{Float64}(undef, env_mβ[k], sys_mα[j])
-                end
+                temp1 = engine_matrix_type(engine)(undef, env_mβ[k], sys_mα[j])
             end
             MPI.Bcast!(temp1, root, comm)
             temp2 = temp1 * sys_trmat[j]
@@ -122,11 +98,7 @@ function _wavefunction_reverse(Ψ0, sys_label, sys, env, widthmax, comm, rank, N
     sys_βs = MPI.bcast(sys.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
     env_βs = MPI.bcast(env.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
 
-    if engine <: GPUEngine
-        Ψ0_new = [[CUDA.zeros(Float64, size(Ψ0[i, j][J], 2), size(Ψ0[i, j][J], 1)) for J in 1 : length(Ψ0[i, j])] for j in 1 : size(Ψ0, 2), i in 1 : size(Ψ0, 1)]
-    else
-        Ψ0_new = [[zeros(size(Ψ0[i, j][J], 2), size(Ψ0[i, j][J], 1)) for J in 1 : length(Ψ0[i, j])] for j in 1 : size(Ψ0, 2), i in 1 : size(Ψ0, 1)]
-    end
+    Ψ0_new = [[zeros_like_engine(engine, Float64, size(Ψ0[i, j][J], 2), size(Ψ0[i, j][J], 1)) for J in 1 : length(Ψ0[i, j])] for j in 1 : size(Ψ0, 2), i in 1 : size(Ψ0, 1)]
 
     for j in 1 : size(Ψ0, 2), i in 1 : size(Ψ0, 1)
         OM = length(Ψ0[i, j])


### PR DESCRIPTION
### Motivation
- Reduce pervasive CPU/GPU branching and duplicated allocation/conversion code by centralizing backend-aware helpers. 
- Make intent explicit when allocating temporary buffers or converting tensors between host and engine representations. 
- Keep all control flow and data layout identical while performing a mechanical deduplication pass.

### Description
- Add `src/engine_utils.jl` implementing `zeros_like_engine(engine, T, dims...)`, `to_engine_array(engine, x)`, `to_host_array(x)`, and `engine_matrix_type(engine)` for backend-aware allocation and conversions. 
- Wire the helper module into package load order via `include("engine_utils.jl")` in `src/SUNDMRG.jl`. 
- Replace repeated engine-dependent allocation/conversion blocks with the new helpers across `src/block.jl`, `src/step.jl`, `src/tools.jl`, and `src/measurement.jl`, using `zeros_like_engine`, `to_engine_array`, `to_host_array`, and `engine_matrix_type` where appropriate. 
- Changes are a mechanical refactor only and do not alter algorithmic control flow or data layout.

### Testing
- Ran `git diff --check` on the workspace to validate patch hygiene and it passed. 
- Attempted to parse the modified Julia sources with a `julia` invocation for a basic syntax check but the `julia` binary was not available in this environment, so parsing could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb7c246c083309a1c13872bc47f0b)