### PR TITLE
Add internal storage adapter for finite DMRG IO paths

### DIFF
--- a/src/SUNDMRG.jl
+++ b/src/SUNDMRG.jl
@@ -19,6 +19,7 @@ export DMRGOutput, run_DMRG, make_table, make_table3nu, make_table4, HeisenbergM
 include("suncalc.jl")
 include("lanczos.jl")
 include("engine_utils.jl")
+include("storage.jl")
 include("block.jl")
 include("measurement.jl")
 include("step.jl")

--- a/src/block.jl
+++ b/src/block.jl
@@ -171,35 +171,21 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
 end
 
 """
-env_tensor_dict = spin_operators!(tensor_table, env, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = :square)
+env_tensor_dict = spin_operators!(storage, env, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = :square)
 generates spin operators for the environment
 """
-function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = :square) where Nc
+function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = :square) where Nc
     env_tensor_dict = engine <: GPUEngine ? Dict{Int, Matrix{Vector{CuMatrix{Float64}}}}() : Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
     y_conn = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(env.length, 2Ly))
     for y in 1 : min(env.length, Ly)
         if lattice != :honeycombZC || y == y_conn || ((mod1(env.length, 2Ly) <= Ly) ? y == 1 : y == Ly) || (y <= y_conn ? iseven(y) : isodd(y))
             if rank == 0
-                if fileio
-                    filename = "$scratch/temp$dirid/tensor_$(env_label)_$(env.length)_$y.jld2"
-                    if isfile(filename)
-                        spin = load_object(filename)::Matrix{Vector{Matrix{Float64}}}
-                        rm(filename)
-                    else
-                        spin = nothing
-                    end
-                else
-                    spin = pop!(tensor_table, (env_label, env.length, y), nothing)
-                end
+                spin = load_tensor(storage, env_label, env.length, y)
 
                 if isnothing(spin)
                     z = max(2Ly * ((env.length - y) ÷ 2Ly) + y, 2Ly * ((env.length - (1 - y)) ÷ 2Ly) + 1 - y)
 
-                    if fileio
-                        env_old = load_object("$scratch/temp$dirid/block_$(env_label)_$(z - 1).jld2")::Block{Nc}
-                    else
-                        env_old = block_table[env_label, z - 1]
-                    end
+                    env_old = load_block(storage, env_label, z - 1)::Block{Nc}
 
                     αs = copy(env_old.β_list)
                     lenα = length(αs)
@@ -235,11 +221,7 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
 
                     Snew = [to_engine_array.(Ref(engine), Stemp[i, j]) for i in 1 : lenβ, j in 1 : lenβ]
 
-                    if fileio
-                        env_trmat = to_engine_array.(Ref(engine), load_object("$scratch/temp$dirid/trmat_$(env_label)_$z.jld2")::Vector{Matrix{Float64}})
-                    else
-                        env_trmat = to_engine_array.(Ref(engine), trmat_table[env_label, z])
-                    end
+                    env_trmat = to_engine_array.(Ref(engine), load_trmat(storage, env_label, z))
 
                     lennew = length(env_trmat)
                     ms = map(k -> size(env_trmat[k], 2), 1 : lennew)
@@ -247,17 +229,9 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
 
                     for x in z + 1 : env.length
                         if engine <: GPUEngine
-                            if fileio
-                                jldsave("$scratch/temp$dirid/tensor_$(env_label)_$(x - 1)_$y.jld2"; env_tensor_dict = [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew])
-                            else
-                                tensor_table[env_label, x - 1, y] = [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew]
-                            end
+                            save_tensor(storage, env_label, x - 1, y, [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew])
                         else
-                            if fileio
-                                jldsave("$scratch/temp$dirid/tensor_$(env_label)_$(x - 1)_$y.jld2"; env_tensor_dict = Sold)
-                            else
-                                tensor_table[env_label, x - 1, y] = deepcopy(Sold)
-                            end
+                            save_tensor(storage, env_label, x - 1, y, deepcopy(Sold))
                         end
 
                         αs = copy(βs)
@@ -289,11 +263,7 @@ function spin_operators!(tensor_table, env::Block{Nc}, env_label, Ly, widthmax, 
                             end
                         end
 
-                        if fileio
-                            env_trmat = to_engine_array.(Ref(engine), load_object("$scratch/temp$dirid/trmat_$(env_label)_$x.jld2")::Vector{Matrix{Float64}})
-                        else
-                            env_trmat = to_engine_array.(Ref(engine), trmat_table[env_label, x])
-                        end
+                        env_trmat = to_engine_array.(Ref(engine), load_trmat(storage, env_label, x))
         
                         lennew = length(env_trmat)
                         ms = map(k -> size(env_trmat[k], 2), 1 : lennew)

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -305,7 +305,7 @@ function _warmup_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_
     return blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, ES
 end
 
-function _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, tensor_table, trmat_table, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
+function _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, tensor_table, trmat_table, storage, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
     L = 2blockL.length
 
     if mirror
@@ -372,7 +372,7 @@ function _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_
                             end
                         end
 
-                        env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
+                        env_tensor_dict = spin_operators!(storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
                     else
                         env_block = Block(L - sys_blocks[i].length - 1, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                         env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
@@ -401,7 +401,7 @@ function _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_
                         end
                     end
 
-                    env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
+                    env_tensor_dict = spin_operators!(storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
                 else
                     env_block = Block(L - sys_blocks[i].length - 2, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                     env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
@@ -464,7 +464,7 @@ function _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_
     return L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, ES
 end
 
-function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, block_table, tensor_table, trmat_table, Ly, L, Nc, m_sweep_list, m_cooldown, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, fileio, scratch, dirid, lattice, alg, correlation, margin, ES_max, tol_energy, tol_EE)
+function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, block_table, tensor_table, trmat_table, storage, Ly, L, Nc, m_sweep_list, m_cooldown, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, fileio, scratch, dirid, lattice, alg, correlation, margin, ES_max, tol_energy, tol_EE)
     Ψ0 = Ψ[1]
 
     sys_label, env_label = :l, :r
@@ -490,7 +490,7 @@ function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_bloc
             end
         end
 
-        env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
+        env_tensor_dict = spin_operators!(storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
     else
         env_block = Block(L - sys_block.length - 1, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
         env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
@@ -532,7 +532,7 @@ function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_bloc
                     end
                 end
 
-                env_tensor_dict = spin_operators!(tensor_table, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, fileio, scratch, dirid, block_table, trmat_table, on_the_fly, engine; lattice = lattice)
+                env_tensor_dict = spin_operators!(storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
             else
                 env_block = Block(L - sys_block.length - 2, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                 env_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
@@ -603,9 +603,9 @@ function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_bloc
     return ES, EE
 end
 
-function _finalize_runtime!(engine, fileio, scratch, dirid, comm)
-    if fileio
-        rm("$scratch/temp$dirid"; recursive = true)
+function _finalize_runtime!(engine, storage, rank, comm)
+    if rank == 0
+        cleanup_storage!(storage)
     end
 
     if engine <: GPUEngine
@@ -640,14 +640,15 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
     on_the_fly, mirror, γ_type, γ_list, N, signfactor = _init_runtime_and_engine(engine, lattice, Lx, Ly, Nc, rank, Ncpu)
 
     m_list, errors, energies, EEs, EE, ES, SiSj, block_table, tensor_table, trmat_table, dirid, blockL, blockL_tensor_dict, blockR, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ = _init_state(engine, lattice, Lx, Ly, Nc, target, m_warmup, widthmax, tables, fileio, scratch, on_the_fly, mirror, γ_type, comm, rank, Ncpu, signfactor)
+    storage = _storage_backend(fileio, scratch, dirid, block_table, trmat_table, tensor_table)
 
     blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, ES = _warmup_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, trmat_table, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
 
-    L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, ES = _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, tensor_table, trmat_table, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
+    L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, ES = _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, block_table, tensor_table, trmat_table, storage, Ly, N, m_warmup, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, mirror, fileio, scratch, dirid, lattice, alg)
 
-    ES, EE = _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, block_table, tensor_table, trmat_table, Ly, L, Nc, m_sweep_list, m_cooldown, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, fileio, scratch, dirid, lattice, alg, correlation, margin, ES_max, tol_energy, tol_EE)
+    ES, EE = _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, block_table, tensor_table, trmat_table, storage, Ly, L, Nc, m_sweep_list, m_cooldown, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_type, γ_list, engine, fileio, scratch, dirid, lattice, alg, correlation, margin, ES_max, tol_energy, tol_EE)
 
-    _finalize_runtime!(engine, rank == 0 && fileio, scratch, dirid, comm)
+    _finalize_runtime!(engine, storage, rank, comm)
 
     ESrtn = Dict{NTuple{Nc, Int}, Vector{Float64}}()
     for (key, value) in ES

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -1,0 +1,79 @@
+abstract type AbstractInternalStorage end
+
+struct MemoryInternalStorage{B, T, TT} <: AbstractInternalStorage
+    block_table::B
+    trmat_table::T
+    tensor_table::TT
+end
+
+struct JLD2InternalStorage <: AbstractInternalStorage
+    scratch::String
+    dirid
+end
+
+_storage_backend(fileio, scratch, dirid, block_table, trmat_table, tensor_table) = fileio ? JLD2InternalStorage(scratch, dirid) : MemoryInternalStorage(block_table, trmat_table, tensor_table)
+
+_block_filename(storage::JLD2InternalStorage, label, len) = "$(storage.scratch)/temp$(storage.dirid)/block_$(label)_$(len).jld2"
+_trmat_filename(storage::JLD2InternalStorage, label, len) = "$(storage.scratch)/temp$(storage.dirid)/trmat_$(label)_$(len).jld2"
+_tensor_filename(storage::JLD2InternalStorage, label, len, y) = "$(storage.scratch)/temp$(storage.dirid)/tensor_$(label)_$(len)_$(y).jld2"
+
+function load_block(storage::MemoryInternalStorage, label, len)
+    storage.block_table[label, len]
+end
+
+function save_block(storage::MemoryInternalStorage, label, len, block)
+    storage.block_table[label, len] = block
+end
+
+function load_trmat(storage::MemoryInternalStorage, label, len)
+    storage.trmat_table[label, len]
+end
+
+function save_trmat(storage::MemoryInternalStorage, label, len, trmat)
+    storage.trmat_table[label, len] = trmat
+end
+
+function load_tensor(storage::MemoryInternalStorage, label, len, y)
+    pop!(storage.tensor_table, (label, len, y), nothing)
+end
+
+function save_tensor(storage::MemoryInternalStorage, label, len, y, tensor)
+    storage.tensor_table[label, len, y] = tensor
+end
+
+function load_block(storage::JLD2InternalStorage, label, len)
+    load_object(_block_filename(storage, label, len))
+end
+
+function save_block(storage::JLD2InternalStorage, label, len, block)
+    jldsave(_block_filename(storage, label, len); env_block = block)
+end
+
+function load_trmat(storage::JLD2InternalStorage, label, len)
+    load_object(_trmat_filename(storage, label, len))::Vector{Matrix{Float64}}
+end
+
+function save_trmat(storage::JLD2InternalStorage, label, len, trmat)
+    jldsave(_trmat_filename(storage, label, len); env_trmat = trmat)
+end
+
+function load_tensor(storage::JLD2InternalStorage, label, len, y)
+    filename = _tensor_filename(storage, label, len, y)
+    if isfile(filename)
+        tensor = load_object(filename)::Matrix{Vector{Matrix{Float64}}}
+        rm(filename)
+        tensor
+    else
+        nothing
+    end
+end
+
+function save_tensor(storage::JLD2InternalStorage, label, len, y, tensor)
+    jldsave(_tensor_filename(storage, label, len, y); env_tensor_dict = tensor)
+end
+
+function cleanup_storage!(storage::JLD2InternalStorage)
+    rm("$(storage.scratch)/temp$(storage.dirid)"; recursive = true)
+end
+
+cleanup_storage!(::MemoryInternalStorage) = nothing


### PR DESCRIPTION
### Motivation
- Reduce duplicated `if fileio ... else ...` branching for block/trmatrix/tensor IO and centralize cleanup logic.
- Provide a lightweight abstraction that supports both in-memory (fast tests) and JLD2 file-backed storage with the same on-disk layout.
- Make the storage backend pluggable and pass it once from runtime init through growth/sweep phases to simplify callers.

### Description
- Add `src/storage.jl` implementing `AbstractInternalStorage` with `MemoryInternalStorage` and `JLD2InternalStorage` and API functions `load_block`/`save_block`, `load_trmat`/`save_trmat`, `load_tensor`/`save_tensor`, and `cleanup_storage!`.
- Preserve existing JLD2 filenames and payload keys (`block_<label>_<len>.jld2` with `env_block`, `trmat_<label>_<len>.jld2` with `env_trmat`, `tensor_<label>_<len>_<y>.jld2` with `env_tensor_dict`) so on-disk data format is unchanged.
- Refactor `spin_operators!` in `src/block.jl` to accept a `storage::AbstractInternalStorage` and replace direct `if fileio` file/dict operations with `load_*`/`save_*` calls.
- Wire the backend into the runtime by including `storage.jl`, creating `storage = _storage_backend(...)` in `_run_DMRG`, threading `storage` into `_growth_phase!` and `_sweep_phase!`, and calling `cleanup_storage!` in `_finalize_runtime!`.

### Testing
- Ran `git diff --check` which returned no whitespace or diff-check errors.
- Attempted to load the package with `julia --project -e 'using SUNDMRG; println("ok")'`, but this run failed due to the environment missing the `julia` binary (`/bin/bash: julia: command not found`), so runtime integration could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebb5c557883308e712af53449625c)