### PR TITLE
Add CPU-only unit tests for dcinit, Lanczos kernels, and on_the_fly helpers

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,7 @@ using SUNDMRG
     include("test_suncalc.jl")
     include("test_sparsevec2.jl")
     include("test_tables_small.jl")
+    include("test_step_helpers.jl")
+    include("test_lanczos_helpers.jl")
+    include("test_tools_onthefly.jl")
 end

--- a/test/test_lanczos_helpers.jl
+++ b/test/test_lanczos_helpers.jl
@@ -1,0 +1,42 @@
+using LinearAlgebra
+
+@testset "Lanczos nested-array helper kernels" begin
+    function nested_fixture(offset::Float64)
+        z = Matrix{Vector{Matrix{Float64}}}(undef, 2, 2)
+        z[1, 1] = [reshape(collect(1.0:4.0) .+ offset, 2, 2), [5.0 + offset 6.0 + offset; 7.0 + offset 8.0 + offset]]
+        z[1, 2] = [[9.0 + offset 10.0 + offset; 11.0 + offset 12.0 + offset]]
+        z[2, 1] = [[13.0 + offset 14.0 + offset; 15.0 + offset 16.0 + offset], [17.0 + offset 18.0 + offset; 19.0 + offset 20.0 + offset]]
+        z[2, 2] = [[21.0 + offset 22.0 + offset; 23.0 + offset 24.0 + offset]]
+        z
+    end
+
+    x = nested_fixture(0.0)
+    y = nested_fixture(0.5)
+
+    manual_dot = 0.0
+    for I in eachindex(x), J in eachindex(x[I])
+        manual_dot += LinearAlgebra.dot(x[I][J], y[I][J])
+    end
+    @test SUNDMRG.mydot(x, y) ≈ manual_dot
+    @test SUNDMRG.mydot(x, y) ≈ SUNDMRG.mydot(y, x)
+
+    y_axpy = deepcopy(y)
+    SUNDMRG.myaxpy!(2.0, x, y_axpy)
+    for I in eachindex(x), J in eachindex(x[I])
+        @test y_axpy[I][J] ≈ y[I][J] .+ 2.0 .* x[I][J]
+    end
+
+    y_axpby = deepcopy(y)
+    SUNDMRG.myaxpby!(1.5, x, -0.25, y_axpby)
+    for I in eachindex(x), J in eachindex(x[I])
+        @test y_axpby[I][J] ≈ 1.5 .* x[I][J] .- 0.25 .* y[I][J]
+    end
+
+    dest = nested_fixture(-100.0)
+    SUNDMRG.mycopyto!(dest, x)
+    @test dest == x
+
+    # Copy must be value-based, not aliasing source storage.
+    x[1, 1][1][1, 1] = -999.0
+    @test dest[1, 1][1][1, 1] != x[1, 1][1][1, 1]
+end

--- a/test/test_step_helpers.jl
+++ b/test/test_step_helpers.jl
@@ -1,0 +1,24 @@
+@testset "dcinit partition helper" begin
+    @test SUNDMRG.dcinit(0, 4) == [0, 0, 0, 0, 0]
+
+    # Edge case: fewer tasks than workers.
+    dc_small = SUNDMRG.dcinit(3, 5)
+    @test length(dc_small) == 6
+    @test dc_small == [0, 0, 1, 1, 2, 3]
+    @test diff(dc_small) == [0, 1, 0, 1, 1]
+
+    # Divisibility case: perfectly even partition.
+    dc_even = SUNDMRG.dcinit(12, 4)
+    @test dc_even == [0, 3, 6, 9, 12]
+    @test all(==(3), diff(dc_even))
+
+    # General monotonic / coverage sanity.
+    for (N, Ncpu) in ((1, 3), (7, 4), (13, 6), (64, 8))
+        dc = SUNDMRG.dcinit(N, Ncpu)
+        @test first(dc) == 0
+        @test last(dc) == N
+        @test issorted(dc)
+        @test all(x -> x in (0, 1, cld(N, Ncpu)), diff(dc))
+        @test maximum(diff(dc)) - minimum(diff(dc)) <= 1
+    end
+end

--- a/test/test_tools_onthefly.jl
+++ b/test/test_tools_onthefly.jl
@@ -1,0 +1,42 @@
+@testset "On-the-fly SU(2) helper kernels (1..5)" begin
+    Nc = 2
+    trivial = SUNDMRG.trivialirrep(Val(Nc))
+    funda = SUNDMRG.fundamentalirrep(Val(Nc))
+    adj = SUNDMRG.adjointirrep(Val(Nc))
+
+    key1 = (trivial, funda, trivial, funda)
+    calc1 = SUNDMRG.on_the_fly_calc1(Nc, key1)
+    ref1 = SUNDMRG.wigner9ν(key1[1], funda, key1[2], adj, trivial, adj, key1[3], funda, key1[4])[:, 1, 1, 1, 1, :]
+    @test size(calc1) == size(ref1)
+    @test calc1 ≈ ref1
+
+    key2 = (trivial, funda, funda)
+    calc2 = SUNDMRG.on_the_fly_calc2(Nc, key2)
+    ref2 = SUNDMRG.wigner6ν(key2[1], funda, key2[2], adj, key2[3], funda)[1, 1, 1, :]
+    @test size(calc2) == size(ref2)
+    @test calc2 ≈ ref2
+
+    key3 = (trivial, funda, trivial)
+    calc3 = SUNDMRG.on_the_fly_calc3(Nc, key3)
+    ref3 = SUNDMRG.wigner9ν(key3[1], funda, key3[2], adj, adj, trivial, key3[3], funda, key3[2])[:, 1, 1, 1, 1, 1]
+    @test size(calc3) == size(ref3)
+    @test calc3 ≈ ref3
+
+    key4 = (funda, funda, trivial, funda, funda)
+    calc4 = SUNDMRG.on_the_fly_calc4(Nc, key4)
+    ref4 = SUNDMRG.wigner9ν(key4[1], key4[2], key4[3], adj, adj, trivial, key4[4], key4[5], key4[3])[:, :, :, :, 1, 1]
+    @test size(calc4) == size(ref4)
+    @test calc4 ≈ ref4
+
+    key5 = (trivial, funda, trivial, trivial, funda)
+    calc5 = SUNDMRG.on_the_fly_calc5(Nc, key5)
+    ref5 = SUNDMRG.wigner6ν(key5[1], funda, key5[2], key5[3], key5[4], key5[5])[1, :, 1, :] .* SUNDMRG.wigner3ν(key5[3], funda, key5[5])[1, 1]
+    @test size(calc5) == size(ref5)
+    @test calc5 ≈ ref5
+
+    # Basic SU(2) symmetry/sanity: real-valued kernels and finite entries.
+    for arr in (calc1, calc2, calc3, calc4, calc5)
+        @test all(isfinite, arr)
+        @test all(x -> iszero(imag(x)), arr)
+    end
+end


### PR DESCRIPTION
### Motivation

- Increase pure-function test coverage for core helper routines so they can be validated without MPI/GPU runtimes. 
- Cover edge cases and invariants in the `dcinit` partitioning logic used by the step code. 
- Verify correctness and non-aliasing behavior of small Lanczos helper kernels and consistency of on-the-fly SU(2) table helpers.

### Description

- Add `test/test_step_helpers.jl` with a focused `dcinit` suite exercising `N < Ncpu`, perfect divisibility, and monotonic/coverage invariants. 
- Add `test/test_lanczos_helpers.jl` that provides a small nested-matrix fixture and tests `mydot`, `myaxpy!`, `myaxpby!`, and `mycopyto!`, including a non-aliasing copy check. 
- Add `test/test_tools_onthefly.jl` with SU(2)-focused checks for `on_the_fly_calc1..5` comparing shapes and values against direct Wigner-slice references and checking real/finite sanity. 
- Wire the new suites into `test/runtests.jl` so they are executed with the existing CPU-only pure tests.

### Testing

- Attempted to run the full test suite with `julia --project test/runtests.jl`, but the environment lacks a `julia` binary so the run could not be executed (`/bin/bash: julia: command not found`).
- No automated tests were run successfully in this execution environment due to the missing Julia runtime.
- All test files were added and wired into the top-level runner; they are ready to run in an environment with Julia available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebec4c46483309e79948f6f7b2b5d)