### PR TITLE
[codex] Refactor DMRG step and finite state flow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.4.4"
+version = "1.4.5"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/src/api.jl
+++ b/src/api.jl
@@ -22,24 +22,13 @@ function run_DMRG end
 
 _dmrg_schedule(m::Int) = (m, 0.0)
 _dmrg_schedule(m::Tuple{Int, Float64}) = m
-_dmrg_schedule_list(ms::Vector{Int}) = _dmrg_schedule.(ms)
-_dmrg_schedule_list(ms::Vector{Tuple{Int, Float64}}) = ms
+_dmrg_schedule_list(ms::AbstractVector) = _dmrg_schedule.(ms)
 
-function run_DMRG(model::HeisenbergModelSU{Nc}, lat::SquareLattice, m_warmup::Int, m_sweep_list::Vector{Int}, m_cooldown::Int, engine::Type{<:Engine}; kwargs...) where Nc
+function run_DMRG(model::HeisenbergModelSU{Nc}, lat::SquareLattice, m_warmup::Union{Int, Tuple{Int, Float64}}, m_sweep_list::AbstractVector, m_cooldown::Union{Int, Tuple{Int, Float64}}, engine::Type{<:Engine}; kwargs...) where Nc
     _run_DMRG(model, :square, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
 end
 
-function run_DMRG(model::HeisenbergModelSU{Nc}, lat::HoneycombLattice, m_warmup::Int, m_sweep_list::Vector{Int}, m_cooldown::Int, engine::Type{<:Engine}; kwargs...) where Nc
-    if lat.BC == :ZC
-        _run_DMRG(model, :honeycombZC, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
-    end
-end
-
-function run_DMRG(model::HeisenbergModelSU{Nc}, lat::SquareLattice, m_warmup::Tuple{Int, Float64}, m_sweep_list::Vector{Tuple{Int, Float64}}, m_cooldown::Tuple{Int, Float64}, engine::Type{<:Engine}; kwargs...) where Nc
-    _run_DMRG(model, :square, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
-end
-
-function run_DMRG(model::HeisenbergModelSU{Nc}, lat::HoneycombLattice, m_warmup::Tuple{Int, Float64}, m_sweep_list::Vector{Tuple{Int, Float64}}, m_cooldown::Tuple{Int, Float64}, engine::Type{<:Engine}; kwargs...) where Nc
+function run_DMRG(model::HeisenbergModelSU{Nc}, lat::HoneycombLattice, m_warmup::Union{Int, Tuple{Int, Float64}}, m_sweep_list::AbstractVector, m_cooldown::Union{Int, Tuple{Int, Float64}}, engine::Type{<:Engine}; kwargs...) where Nc
     if lat.BC == :ZC
         _run_DMRG(model, :honeycombZC, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
     end

--- a/src/block.jl
+++ b/src/block.jl
@@ -1,7 +1,7 @@
 struct Block{Nc}
     length::Int
     bonds::Vector{Tuple{Int, Int}}
-    β_list::Vector{<:SUNIrrep{Nc}}
+    β_list::Vector{SUNIrrep{Nc}}
     mβ_list_old::Vector{Int}
     mβ_list::Vector{Int}
     scalar_dict::Dict{Symbol, Vector{Matrix{Float64}}}
@@ -12,9 +12,9 @@ abstract type EnlargedBlock{Nc} end
 struct EnlargedBlockCPU{Nc} <: EnlargedBlock{Nc}
     length::Int
     bonds::Vector{Tuple{Int, Int}}
-    α_list::Vector{<:SUNIrrep{Nc}}
+    α_list::Vector{SUNIrrep{Nc}}
     mα_list::Vector{Int}
-    β_list::Vector{<:SUNIrrep{Nc}}
+    β_list::Vector{SUNIrrep{Nc}}
     mβ_list::Vector{Int}
     mαβ::Matrix{Int}
     scalar_dict::Dict{Symbol, Vector{Matrix{Float64}}}
@@ -24,13 +24,46 @@ end
 struct EnlargedBlockGPU{Nc} <: EnlargedBlock{Nc}
     length::Int
     bonds::Vector{Tuple{Int, Int}}
-    α_list::Vector{<:SUNIrrep{Nc}}
+    α_list::Vector{SUNIrrep{Nc}}
     mα_list::Vector{Int}
-    β_list::Vector{<:SUNIrrep{Nc}}
+    β_list::Vector{SUNIrrep{Nc}}
     mβ_list::Vector{Int}
     mαβ::Matrix{Int}
     scalar_dict::Dict{Symbol, Vector{CuMatrix{Float64}}}
     tensor_dict::Dict{Int, Matrix{Vector{CuMatrix{Float64}}}}
+end
+
+function _build_spin_tensor(Nc, αs, βs, mαβ, αβmatrix, cum_mαβ, tables, on_the_fly)
+    fac = sqrt((Nc ^ 2 - 1) / Nc)
+    lenα = length(αs)
+    lenβ = length(βs)
+    ms = cum_mαβ[end, :]
+    adjoint = adjointirrep(Val(Nc))
+    dp = [directproduct(βs[j], adjoint) for j in 1 : lenβ]
+
+    map([(i, j) for i in 1 : lenβ, j in 1 : lenβ]) do (i, j)
+        o1 = get(dp[j], βs[i], 0)
+        map(1 : o1) do τ1
+            rtn = zeros(ms[i], ms[j])
+            for k in 1 : lenα
+                if αβmatrix[k, i] && αβmatrix[k, j]
+                    coeff = on_the_fly ? on_the_fly_calc2(Nc, (αs[k], βs[j], βs[i])) : tables[2][αs[k], βs[j], βs[i]]
+                    for l in 1 : mαβ[k, i]
+                        rtn[cum_mαβ[k, i] + l, cum_mαβ[k, j] + l] = fac * coeff[τ1]
+                    end
+                end
+            end
+            rtn
+        end
+    end
+end
+
+function _make_enlarged_block(::Type{<:CPUEngine}, ::Val{Nc}, len, bonds, αs, mαs, βs, ms, mαβ, Hnew, tensor_dict) where Nc
+    EnlargedBlockCPU{Nc}(len, bonds, αs, mαs, βs, ms, mαβ, Dict{Symbol, Vector{Matrix{Float64}}}(:H => Hnew), tensor_dict)
+end
+
+function _make_enlarged_block(::Type{<:GPUEngine}, ::Val{Nc}, len, bonds, αs, mαs, βs, ms, mαβ, Hnew, tensor_dict) where Nc
+    EnlargedBlockGPU{Nc}(len, bonds, αs, mαs, βs, ms, mαβ, Dict{Symbol, Vector{CuMatrix{Float64}}}(:H => Hnew), tensor_dict)
 end
 
 """
@@ -42,7 +75,6 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
         αs = copy(block.β_list)
         lenα = length(αs)
         funda = fundamentalirrep(Val(Nc))
-        adjoint = adjointirrep(Val(Nc))
 
         dest = map(α -> unique(keys(directproduct(α, funda))), αs)
         βs = sort!(filter!(β -> on_the_fly || weight(β)[1] <= widthmax, union(dest[block.mβ_list .> 0]...)))
@@ -55,25 +87,9 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
     end
 
     zy = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(block.length + 1, 2Ly))
-    tensor_dict = engine <: GPUEngine ? Dict{Int, Matrix{Vector{CuMatrix{Float64}}}}() : Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
+    tensor_dict = empty_engine_tensor_dict(engine)
     if rank == 0
-        fac1 = sqrt((Nc ^ 2 - 1) / Nc)
-        dp = [directproduct(βs[j], adjoint) for j in 1 : lenβ]
-        Stemp = map([(i, j) for i in 1 : lenβ, j in 1 : lenβ]) do (i, j)
-            o1 = get(dp[j], βs[i], 0)
-            map(1 : o1) do τ1
-                rtn = zeros(ms[i], ms[j])
-                for k in 1 : lenα
-                    if αβmatrix[k, i] && αβmatrix[k, j]
-                        coeff = on_the_fly ? on_the_fly_calc2(Nc, (αs[k], βs[j], βs[i])) : tables[2][αs[k], βs[j], βs[i]]
-                        for l in 1 : mαβ[k, i]
-                            rtn[cum_mαβ[k, i] + l, cum_mαβ[k, j] + l] = fac1 * coeff[τ1]
-                        end
-                    end
-                end
-                rtn
-            end
-        end
+        Stemp = _build_spin_tensor(Nc, αs, βs, mαβ, αβmatrix, cum_mαβ, tables, on_the_fly)
         MPI.bcast(ms, 0, comm)
         om = length.(Stemp)
         MPI.bcast(om, 0, comm)
@@ -121,11 +137,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
                                     coeff = on_the_fly ? on_the_fly_calc3(Nc, (αs[j], βs[k], αs[i])) : tables[3][αs[j], βs[k], αs[i]]
                                     for τ1 in 1 : o1
                                         temp2 = fac2 * coeff[τ1]
-                                        # if engine <: GPUEngine
-                                        #     temp3 = CuArray(block_tensor_dict[z][i, j][τ1])
-                                        # else
                                         temp3 = block_tensor_dict[z][i, j][τ1]
-                                        # end
                                         @. rtn[cum_mαβ[i, k] + 1 : cum_mαβ[i + 1, k], cum_mαβ[j, k] + 1 : cum_mαβ[j + 1, k]] += temp2 * temp3
                                     end
                                 end
@@ -153,21 +165,14 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
         MPI.Bcast!(Hnew[k], 0, comm)
     end
 
-    if rank == 0
-        if engine <: GPUEngine
-            block_enl = EnlargedBlockGPU{Nc}(block.length + 1, bonds, αs, copy(block.mβ_list_old), βs, ms, mαβ, Dict{Symbol, Vector{CuMatrix{Float64}}}(:H => Hnew), tensor_dict)
-        else
-            block_enl = EnlargedBlockCPU{Nc}(block.length + 1, bonds, αs, copy(block.mβ_list_old), βs, ms, mαβ, Dict{Symbol, Vector{Matrix{Float64}}}(:H => Hnew), tensor_dict)
-        end
-    else
-        if engine <: GPUEngine
-            block_enl = EnlargedBlockGPU{Nc}(block.length + 1, Tuple{Int, Int}[], typeof(trivialirrep(Val(Nc)))[], Int[], typeof(trivialirrep(Val(Nc)))[], Int[], zeros(Int, 0, 0), Dict{Symbol, Vector{CuMatrix{Float64}}}(:H => Hnew), tensor_dict)
-        else
-            block_enl = EnlargedBlockCPU{Nc}(block.length + 1, Tuple{Int, Int}[], typeof(trivialirrep(Val(Nc)))[], Int[], typeof(trivialirrep(Val(Nc)))[], Int[], zeros(Int, 0, 0), Dict{Symbol, Vector{Matrix{Float64}}}(:H => Hnew), tensor_dict)
-        end
+    if rank != 0
+        bonds = Tuple{Int, Int}[]
+        αs = typeof(trivialirrep(Val(Nc)))[]
+        βs = typeof(trivialirrep(Val(Nc)))[]
+        mαβ = zeros(Int, 0, 0)
     end
 
-    block_enl
+    _make_enlarged_block(engine, Val(Nc), block.length + 1, bonds, αs, rank == 0 ? copy(block.mβ_list_old) : Int[], βs, ms, mαβ, Hnew, tensor_dict)
 end
 
 """
@@ -175,7 +180,7 @@ env_tensor_dict = spin_operators!(storage, env, env_label, Ly, widthmax, signfac
 generates spin operators for the environment
 """
 function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = :square) where Nc
-    env_tensor_dict = engine <: GPUEngine ? Dict{Int, Matrix{Vector{CuMatrix{Float64}}}}() : Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
+    env_tensor_dict = empty_engine_tensor_dict(engine)
     y_conn = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(env.length, 2Ly))
     for y in 1 : min(env.length, Ly)
         if lattice != :honeycombZC || y == y_conn || ((mod1(env.length, 2Ly) <= Ly) ? y == 1 : y == Ly) || (y <= y_conn ? iseven(y) : isodd(y))
@@ -201,23 +206,7 @@ function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_l
                     cum_mαβ = vcat(zeros(Int, 1, lenβ), cumsum(mαβ, dims = 1))
                     ms = cum_mαβ[end, :]
 
-                    fac1 = sqrt((Nc ^ 2 - 1) / Nc)
-                    dp = [directproduct(βs[j], adjoint) for j in 1 : lenβ]
-                    Stemp = map([(i, j) for i in 1 : lenβ, j in 1 : lenβ]) do (i, j)
-                        o1 = get(dp[j], βs[i], 0)
-                        map(1 : o1) do τ1
-                            rtn = zeros(ms[i], ms[j])
-                            for k in 1 : lenα
-                                if αβmatrix[k, i] && αβmatrix[k, j]
-                                    coeff = on_the_fly ? on_the_fly_calc2(Nc, (αs[k], βs[j], βs[i])) : tables[2][αs[k], βs[j], βs[i]]
-                                    for l in 1 : mαβ[k, i]
-                                        rtn[cum_mαβ[k, i] + l, cum_mαβ[k, j] + l] = fac1 * coeff[τ1]
-                                    end
-                                end
-                            end
-                            rtn
-                        end
-                    end
+                    Stemp = _build_spin_tensor(Nc, αs, βs, mαβ, αβmatrix, cum_mαβ, tables, on_the_fly)
 
                     Snew = [to_engine_array.(Ref(engine), Stemp[i, j]) for i in 1 : lenβ, j in 1 : lenβ]
 
@@ -225,7 +214,7 @@ function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_l
 
                     lennew = length(env_trmat)
                     ms = map(k -> size(env_trmat[k], 2), 1 : lennew)
-                    Sold = map(k -> isempty(Snew[k...]) ? (engine <: GPUEngine ? CuMatrix{Float64}[] : Matrix{Float64}[]) : [env_trmat[k[1]]' * (M * env_trmat[k[2]]) for M in Snew[k...]], [(ki, kj) for ki in 1 : lennew, kj in 1 : lennew])
+                    Sold = map(k -> isempty(Snew[k...]) ? empty_engine_matrix_vector(engine) : [env_trmat[k[1]]' * (M * env_trmat[k[2]]) for M in Snew[k...]], [(ki, kj) for ki in 1 : lennew, kj in 1 : lennew])
 
                     for x in z + 1 : env.length
                         if engine <: GPUEngine

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -19,24 +19,25 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         config = _FiniteRunConfig(lattice, Lx, Ly, N, Nc, m_warmup, m_sweep_list, m_cooldown, target, widthmax, tables, fileio, scratch, ES_max, tol_energy, tol_EE, correlation, margin, alg, verbose)
         runtime = _FiniteRuntime(engine, comm, rank, Ncpu, on_the_fly, mirror, γ_type, γ_list, signfactor)
 
-        m_list, errors, energies, EEs, EE, ES, SiSj, storage, blockL, blockL_tensor_dict, blockR, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ = _init_state(config, runtime)
+        state = _init_state(config, runtime)
+        storage = state.storage
 
-        blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, ES = _warmup_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, storage, config, runtime)
+        _warmup_phase!(state, config, runtime)
 
-        L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, ES = _growth_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, storage, config, runtime)
+        growth = _growth_phase!(state, config, runtime)
 
-        ES, EE = _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, storage, L, config, runtime)
+        state.ES, state.EE = _sweep_phase!(state.SiSj, state.Ψ, state.EE, state.ES, state.m_list, state.errors, state.energies, state.EEs, growth.sys_blocks, growth.sys_tensor_dicts, growth.sys_trmats, growth.sys_block_enls, state.storage, growth.L, config, runtime)
 
         ESrtn = Dict{NTuple{Nc, Int}, Vector{Float64}}()
-        for (key, value) in ES
+        for (key, value) in state.ES
             ESrtn[weight(key)] = value
         end
 
         if Nc == 2
-            map!(x -> 0.5x, values(SiSj))
+            map!(x -> 0.5x, values(state.SiSj))
         end
 
-        return rank, rank == 0 ? DMRGOutput(m_list, errors, energies, EEs, EE, ESrtn, SiSj) : nothing
+        return rank, rank == 0 ? DMRGOutput(state.m_list, state.errors, state.energies, state.EEs, state.EE, ESrtn, state.SiSj) : nothing
     finally
         if runtime_initialized
             _finalize_runtime!(engine, storage, rank)

--- a/src/finite_config.jl
+++ b/src/finite_config.jl
@@ -1,22 +1,52 @@
-struct _FiniteRunConfig
-    lattice
+const _DMRGSchedule = Tuple{Int, Float64}
+
+struct _FiniteRunConfig{L,T,S,C,A}
+    lattice::L
     Lx::Int
     Ly::Int
     N::Int
     Nc::Int
-    m_warmup
-    m_sweep_list
-    m_cooldown
-    target
-    widthmax
-    tables
+    m_warmup::_DMRGSchedule
+    m_sweep_list::Vector{_DMRGSchedule}
+    m_cooldown::_DMRGSchedule
+    target::Int
+    widthmax::Int
+    tables::T
     fileio::Bool
-    scratch
-    ES_max
-    tol_energy
-    tol_EE
-    correlation
-    margin
-    alg
+    scratch::S
+    ES_max::Float64
+    tol_energy::Float64
+    tol_EE::Float64
+    correlation::C
+    margin::Int
+    alg::A
     verbose::Bool
+end
+
+mutable struct _FiniteState{Nc,StorageT,BLT,TLT,BRT,TRT,BELT,BERT,TrLT,TrRT,ΨT}
+    m_list::Vector{_DMRGSchedule}
+    errors::Vector{Float64}
+    energies::Vector{Float64}
+    EEs::Vector{Float64}
+    EE::Vector{Float64}
+    ES::Dict{SUNIrrep{Nc}, Vector{Float64}}
+    SiSj::Dict{Tuple{Int, Int}, Float64}
+    storage::StorageT
+    blockL::BLT
+    blockL_tensor_dict::TLT
+    blockR::BRT
+    blockR_tensor_dict::TRT
+    blockL_enl::BELT
+    blockR_enl::BERT
+    trmatL::TrLT
+    trmatR::TrRT
+    Ψ::ΨT
+end
+
+mutable struct _GrowthState{BlocksT,TensorsT,TrmatsT,EnlsT}
+    L::Int
+    sys_blocks::BlocksT
+    sys_tensor_dicts::TensorsT
+    sys_trmats::TrmatsT
+    sys_block_enls::EnlsT
 end

--- a/src/finite_phases.jl
+++ b/src/finite_phases.jl
@@ -1,9 +1,30 @@
-function _record_phase_result!(m_list, errors, energies, EEs, m, result::DMRGStepResult)
+function _record_step_result!(m_list, errors, energies, EEs, m, result::DMRGStepResult)
     push!(m_list, m)
     push!(errors, result.trerr)
     push!(energies, result.energy)
     push!(EEs, result.ee)
     return result.es
+end
+
+function _apply_left_step_result!(state::_FiniteState, result::DMRGStepResult)
+    state.blockL = result.block
+    state.blockL_tensor_dict = result.tensor_dict
+    state.blockL_enl = result.block_enl
+    state.Ψ[1] = result.Ψ
+    state.trmatL = result.trmat
+    return result.es
+end
+
+function _apply_mirror_env_result!(state::_FiniteState, result::DMRGStepResult, config::_FiniteRunConfig, runtime::_FiniteRuntime)
+    (; widthmax, tables) = config
+    (; comm, rank, Ncpu, on_the_fly, γ_list, engine) = runtime
+
+    state.blockR = result.env_block
+    state.blockR_tensor_dict = result.env_tensor_dict
+    state.blockR_enl = result.env_block_enl
+    state.trmatR = result.env_trmat
+    state.Ψ[2] = wavefunction_reverse(state.Ψ[1], :l, state.blockL, state.blockR, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
+    return nothing
 end
 
 function _log_phase_result(runtime::_FiniteRuntime, verbose, energy, L, ee)
@@ -108,63 +129,80 @@ function _init_state(config::_FiniteRunConfig, runtime::_FiniteRuntime)
 
     Ψ = empty_engine_tensor_matrices(engine, mirror ? 1 : 2)
 
-    return m_list, errors, energies, EEs, EE, ES, SiSj, storage, blockL, blockL_tensor_dict, blockR, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ
+    return _FiniteState{Nc,typeof(storage),typeof(blockL),typeof(blockL_tensor_dict),typeof(blockR),typeof(blockR_tensor_dict),typeof(blockL_enl),typeof(blockR_enl),typeof(trmatL),typeof(trmatR),typeof(Ψ)}(
+        m_list,
+        errors,
+        energies,
+        EEs,
+        EE,
+        ES,
+        SiSj,
+        storage,
+        blockL,
+        blockL_tensor_dict,
+        blockR,
+        blockR_tensor_dict,
+        blockL_enl,
+        blockR_enl,
+        trmatL,
+        trmatR,
+        Ψ,
+    )
 end
 
-function _warmup_phase!(SiSj, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, storage, config::_FiniteRunConfig, runtime::_FiniteRuntime)
+function _warmup_phase!(state::_FiniteState, config::_FiniteRunConfig, runtime::_FiniteRuntime)
     (; lattice, Ly, N, m_warmup, widthmax, target, tables, alg, verbose) = config
     (; engine, comm, rank, Ncpu, on_the_fly, mirror, γ_list, signfactor) = runtime
 
-    while blockL.length < Ly
+    while state.blockL.length < Ly
         if verbose && isroot(runtime)
             if mirror
-                root_println(runtime, graphic(blockL, blockL))
+                root_println(runtime, graphic(state.blockL, state.blockL))
             else
-                root_println(runtime, graphic(blockL, blockR))
+                root_println(runtime, graphic(state.blockL, state.blockR))
             end
         end
 
         if mirror
-            result = dmrg_step_result!(SiSj, :l, blockL, blockL, blockL_tensor_dict, blockL_tensor_dict, blockL_enl, blockL_enl, Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); lattice = lattice, alg = alg, noisy = verbose)
-            blockL, blockL_tensor_dict, blockL_enl, trerr, energy, Ψ[1], trmatL, ee, es = result.block, result.tensor_dict, result.block_enl, result.trerr, result.energy, result.Ψ, result.trmat, result.ee, result.es
+            result = dmrg_step_result!(state.SiSj, :l, state.blockL, state.blockL, state.blockL_tensor_dict, state.blockL_tensor_dict, state.blockL_enl, state.blockL_enl, Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); lattice = lattice, alg = alg, noisy = verbose)
+            _apply_left_step_result!(state, result)
         else
-            result = dmrg_step_result!(SiSj, :l, blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(true); lattice = lattice, alg = alg, noisy = verbose)
-            blockL, blockL_tensor_dict, blockL_enl, trerr, energy, Ψ[1], trmatL, ee, es = result.block, result.tensor_dict, result.block_enl, result.trerr, result.energy, result.Ψ, result.trmat, result.ee, result.es
-            blockR, blockR_tensor_dict, blockR_enl, trmatR = result.env_block, result.env_tensor_dict, result.env_block_enl, result.env_trmat
-            Ψ[2] = wavefunction_reverse(Ψ[1], :l, blockL, blockR, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
+            result = dmrg_step_result!(state.SiSj, :l, state.blockL, state.blockR, state.blockL_tensor_dict, state.blockR_tensor_dict, state.blockL_enl, state.blockR_enl, Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(true); lattice = lattice, alg = alg, noisy = verbose)
+            _apply_left_step_result!(state, result)
+            _apply_mirror_env_result!(state, result, config, runtime)
         end
 
-        if 2blockL.length == N
-            ES = _record_phase_result!(m_list, errors, energies, EEs, m_warmup, result)
+        if 2state.blockL.length == N
+            state.ES = _record_step_result!(state.m_list, state.errors, state.energies, state.EEs, m_warmup, result)
         end
 
-        _log_phase_result(runtime, verbose, energy, 2blockL.length, ee)
-        _save_edge_blocks!(storage, mirror, blockL, trmatL, blockR, trmatR, runtime)
+        _log_phase_result(runtime, verbose, result.energy, 2state.blockL.length, result.ee)
+        _save_edge_blocks!(state.storage, mirror, state.blockL, state.trmatL, state.blockR, state.trmatR, runtime)
     end
 
-    return blockL, blockR, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, ES
+    return state
 end
 
-function _growth_phase!(SiSj, blockL::Block{Nc}, blockR::Block{Nc}, blockL_tensor_dict, blockR_tensor_dict, blockL_enl, blockR_enl, trmatL, trmatR, Ψ, m_list, errors, energies, EEs, ES, storage, config::_FiniteRunConfig, runtime::_FiniteRuntime) where Nc
+function _growth_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runtime::_FiniteRuntime) where Nc
     (; lattice, Ly, N, m_warmup, widthmax, target, tables, alg, verbose) = config
     (; engine, comm, rank, Ncpu, on_the_fly, mirror, γ_type, γ_list, signfactor) = runtime
 
-    L = 2blockL.length
+    L = 2state.blockL.length
 
     if mirror
-        sys_blocks = [blockL]
-        sys_tensor_dicts = [blockL_tensor_dict]
-        sys_trmats = [trmatL]
-        sys_block_enls = [blockL_enl]
-        env_trmats = [trmatL]
-        env_block_enls = [blockL_enl]
+        sys_blocks = [state.blockL]
+        sys_tensor_dicts = [state.blockL_tensor_dict]
+        sys_trmats = [state.trmatL]
+        sys_block_enls = [state.blockL_enl]
+        env_trmats = [state.trmatL]
+        env_block_enls = [state.blockL_enl]
     else
-        sys_blocks = [blockL, blockR]
-        sys_tensor_dicts = [blockL_tensor_dict, blockR_tensor_dict]
-        sys_trmats = [trmatL, trmatR]
-        sys_block_enls = [blockL_enl, blockR_enl]
-        env_trmats = [trmatR, trmatL]
-        env_block_enls = [blockR_enl, blockL_enl]
+        sys_blocks = [state.blockL, state.blockR]
+        sys_tensor_dicts = [state.blockL_tensor_dict, state.blockR_tensor_dict]
+        sys_trmats = [state.trmatL, state.trmatR]
+        sys_block_enls = [state.blockL_enl, state.blockR_enl]
+        env_trmats = [state.trmatR, state.trmatL]
+        env_block_enls = [state.blockR_enl, state.blockL_enl]
     end
 
     while L < N
@@ -179,16 +217,16 @@ function _growth_phase!(SiSj, blockL::Block{Nc}, blockR::Block{Nc}, blockL_tenso
 
             L = 2sys_block_enls[1].length
             if mirror
-                result = dmrg_step_result!(SiSj, :l, sys_blocks[1], sys_blocks[1], sys_tensor_dicts[1], sys_tensor_dicts[1], sys_block_enls[1], sys_block_enls[1], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); lattice = lattice, alg = alg, noisy = verbose)
-                sys_blocks[1], sys_tensor_dicts[1], sys_block_enls[1], trerr, energy, Ψ[1], sys_trmats[1], ee, es = result.block, result.tensor_dict, result.block_enl, result.trerr, result.energy, result.Ψ, result.trmat, result.ee, result.es
+                result = dmrg_step_result!(state.SiSj, :l, sys_blocks[1], sys_blocks[1], sys_tensor_dicts[1], sys_tensor_dicts[1], sys_block_enls[1], sys_block_enls[1], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); lattice = lattice, alg = alg, noisy = verbose)
+                sys_blocks[1], sys_tensor_dicts[1], sys_block_enls[1], state.Ψ[1], sys_trmats[1] = result.block, result.tensor_dict, result.block_enl, result.Ψ, result.trmat
             else
-                result = dmrg_step_result!(SiSj, :l, sys_blocks[1], sys_blocks[2], sys_tensor_dicts[1], sys_tensor_dicts[2], sys_block_enls[1], sys_block_enls[2], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(true); lattice = lattice, alg = alg, noisy = verbose)
-                sys_blocks[1], sys_tensor_dicts[1], sys_block_enls[1], trerr, energy, Ψ[1], sys_trmats[1], ee, es = result.block, result.tensor_dict, result.block_enl, result.trerr, result.energy, result.Ψ, result.trmat, result.ee, result.es
+                result = dmrg_step_result!(state.SiSj, :l, sys_blocks[1], sys_blocks[2], sys_tensor_dicts[1], sys_tensor_dicts[2], sys_block_enls[1], sys_block_enls[2], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(true); lattice = lattice, alg = alg, noisy = verbose)
+                sys_blocks[1], sys_tensor_dicts[1], sys_block_enls[1], state.Ψ[1], sys_trmats[1] = result.block, result.tensor_dict, result.block_enl, result.Ψ, result.trmat
                 sys_blocks[2], sys_tensor_dicts[2], sys_block_enls[2], sys_trmats[2] = result.env_block, result.env_tensor_dict, result.env_block_enl, result.env_trmat
-                Ψ[2] = wavefunction_reverse(Ψ[1], :l, sys_blocks[1], sys_blocks[2], widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
+                state.Ψ[2] = wavefunction_reverse(state.Ψ[1], :l, sys_blocks[1], sys_blocks[2], widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
             end
 
-            _log_phase_result(runtime, verbose, energy, L, ee)
+            _log_phase_result(runtime, verbose, result.energy, L, result.ee)
         else
             for i in 1 : (mirror ? 1 : 2)
                 if i == 1
@@ -198,9 +236,9 @@ function _growth_phase!(SiSj, blockL::Block{Nc}, blockR::Block{Nc}, blockL_tenso
                 end
                 if sys_blocks[i].length % Ly == 0
                     if isroot(runtime)
-                        env_block, env_trmats[i] = load_block_and_trmat(storage, env_label, L - sys_blocks[i].length - 1, engine, Val(Nc))
+                        env_block, env_trmats[i] = load_block_and_trmat(state.storage, env_label, L - sys_blocks[i].length - 1, engine, Val(Nc))
 
-                        env_tensor_dict = spin_operators!(storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
+                        env_tensor_dict = spin_operators!(state.storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
                     else
                         env_block = Block(L - sys_blocks[i].length - 1, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                         env_tensor_dict = empty_engine_tensor_dict(engine)
@@ -210,12 +248,12 @@ function _growth_phase!(SiSj, blockL::Block{Nc}, blockR::Block{Nc}, blockL_tenso
                     env_block_enls[i] = enlarge_block(env_block, env_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
                 end
 
-                Ψ0_guess = eig_prediction(Ψ[i], sys_label, sys_block_enls[i], env_block_enls[i], sys_trmats[i], env_trmats[i], widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
+                Ψ0_guess = eig_prediction(state.Ψ[i], sys_label, sys_block_enls[i], env_block_enls[i], sys_trmats[i], env_trmats[i], widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
 
                 if isroot(runtime)
-                    env_block, env_trmats[i] = load_block_and_trmat(storage, env_label, L - sys_blocks[i].length - 2, engine, Val(Nc))
+                    env_block, env_trmats[i] = load_block_and_trmat(state.storage, env_label, L - sys_blocks[i].length - 2, engine, Val(Nc))
 
-                    env_tensor_dict = spin_operators!(storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
+                    env_tensor_dict = spin_operators!(state.storage, env_block, env_label, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
                 else
                     env_block = Block(L - sys_blocks[i].length - 2, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
                     env_tensor_dict = empty_engine_tensor_dict(engine)
@@ -228,21 +266,21 @@ function _growth_phase!(SiSj, blockL::Block{Nc}, blockR::Block{Nc}, blockL_tenso
                     root_println(runtime, graphic(sys_blocks[i], env_block; sys_label = sys_label))
                 end
 
-                result = dmrg_step_result!(SiSj, sys_label, sys_blocks[i], env_block, sys_tensor_dicts[i], env_tensor_dict, sys_block_enls[i], env_block_enls[i], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); Ψ0_guess = Ψ0_guess, lattice = lattice, alg = alg, noisy = verbose && i == 1)
-                sys_blocks[i], sys_tensor_dicts[i], sys_block_enls[i], trerr, energy, Ψ[i], sys_trmats[i], ee, es = result.block, result.tensor_dict, result.block_enl, result.trerr, result.energy, result.Ψ, result.trmat, result.ee, result.es
+                result = dmrg_step_result!(state.SiSj, sys_label, sys_blocks[i], env_block, sys_tensor_dicts[i], env_tensor_dict, sys_block_enls[i], env_block_enls[i], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); Ψ0_guess = Ψ0_guess, lattice = lattice, alg = alg, noisy = verbose && i == 1)
+                sys_blocks[i], sys_tensor_dicts[i], sys_block_enls[i], state.Ψ[i], sys_trmats[i] = result.block, result.tensor_dict, result.block_enl, result.Ψ, result.trmat
 
-                _log_phase_result(runtime, verbose && i == 1, energy, L, ee)
+                _log_phase_result(runtime, verbose && i == 1, result.energy, L, result.ee)
             end
         end
 
         if L == N
-            ES = _record_phase_result!(m_list, errors, energies, EEs, m_warmup, result)
+            state.ES = _record_step_result!(state.m_list, state.errors, state.energies, state.EEs, m_warmup, result)
         end
 
-        _save_edge_blocks!(storage, mirror, sys_blocks[1], sys_trmats[1], sys_blocks[end], sys_trmats[end], runtime)
+        _save_edge_blocks!(state.storage, mirror, sys_blocks[1], sys_trmats[1], sys_blocks[end], sys_trmats[end], runtime)
     end
 
-    return L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, ES
+    return _GrowthState(L, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls)
 end
 
 function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_blocks, sys_tensor_dicts, sys_trmats, sys_block_enls, storage, L, config::_FiniteRunConfig, runtime::_FiniteRuntime)
@@ -266,7 +304,7 @@ function _sweep_phase!(SiSj, Ψ, EE, ES, m_list, errors, energies, EEs, sys_bloc
             result = _sweep_step!(SiSj, state, EE, storage, L, m, measurement, config, runtime, Val(Nc))
 
             if state.sys_label == :l && 2state.sys_block.length == L
-                ES = _record_sweep_result!(m_list, errors, energies, EEs, m, result)
+                ES = _record_step_result!(m_list, errors, energies, EEs, m, result)
                 break
             end
         end

--- a/src/finite_sweep.jl
+++ b/src/finite_sweep.jl
@@ -1,16 +1,16 @@
-mutable struct _SweepState
-    Ψ0
-    Sj
+mutable struct _SweepState{ΨT,SjT,SysBlockT,EnvBlockT,SysTensorT,EnvTensorT,SysTrmatT,EnvTrmatT,SysEnlT,EnvEnlT}
+    Ψ0::ΨT
+    Sj::SjT
     sys_label::Symbol
     env_label::Symbol
-    sys_block
-    env_block
-    sys_tensor_dict
-    env_tensor_dict
-    sys_trmat
-    env_trmat
-    sys_block_enl
-    env_block_enl
+    sys_block::SysBlockT
+    env_block::EnvBlockT
+    sys_tensor_dict::SysTensorT
+    env_tensor_dict::EnvTensorT
+    sys_trmat::SysTrmatT
+    env_trmat::EnvTrmatT
+    sys_block_enl::SysEnlT
+    env_block_enl::EnvEnlT
 end
 
 function _load_sweep_env(storage, env_label, env_len, config::_FiniteRunConfig, runtime::_FiniteRuntime, ::Val{Nc}) where Nc
@@ -103,14 +103,6 @@ function _sweep_step!(SiSj, state::_SweepState, EE, storage, L, m, measurement, 
     end
 
     return result
-end
-
-function _record_sweep_result!(m_list, errors, energies, EEs, m, result::DMRGStepResult)
-    push!(m_list, m)
-    push!(errors, result.trerr)
-    push!(energies, result.energy)
-    push!(EEs, result.ee)
-    return result.es
 end
 
 function _update_measurement_flag(measurement, energies, EEs, config::_FiniteRunConfig, runtime::_FiniteRuntime)

--- a/src/step.jl
+++ b/src/step.jl
@@ -1,16 +1,7 @@
-function _dmrg_step_tuple(::Val{env_calc}, newblock, newtensor_dict, newblock_enl, truncation_error, energy, Ψ0, trmat, ee, es, Sj) where env_calc
-    if env_calc
-        return newblock[1], newtensor_dict[1], newblock_enl[1], truncation_error[1], energy, Ψ0, trmat[1], ee[1], es[1], newblock[2], newtensor_dict[2], newblock_enl[2], trmat[2]
-    end
-
-    return newblock[1], newtensor_dict[1], newblock_enl[1], truncation_error[1], energy, Ψ0, trmat[1], ee[1], es[1], Sj
-end
-
 """
     dmrg_step!(...)
 
-A single DMRG step. This keeps the historical tuple return value; finite-run
-drivers should prefer `dmrg_step_result!` so field access is explicit.
+A single DMRG step, returned as a `DMRGStepResult` with explicit fields.
 """
 function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_dict, env_tensor_dict, sys_enl::EnlargedBlock{Nc}, env_enl::EnlargedBlock{Nc}, Ly, m, α, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, ::Val{env_calc}; Ψ0_guess = nothing, ES_max = -Inf, correlation = :none, margin = 0, lattice = :square, Sj = Matrix{Vector{Matrix{Float64}}}(undef, 0, 0), alg = :slow, noisy = true) where {Nc, env_calc}
     workspace = _prepare_step_workspace(sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, lattice, Val(Nc))
@@ -88,54 +79,41 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
     end
 
     _report_overlap(Ψ0_guess, Ψ0, comm, rank, noisy)
-    return _dmrg_step_tuple(Val(env_calc), newblock, newtensor_dict, newblock_enl, truncation_error, energy, Ψ0, trmat, ee, es, Sj)
-end
-
-struct DMRGStepResult
-    block
-    tensor_dict
-    block_enl
-    trerr
-    energy
-    Ψ
-    trmat
-    ee
-    es
-    Sj
-    env_block
-    env_tensor_dict
-    env_block_enl
-    env_trmat
-end
-
-function _dmrg_step_result(parts::Tuple)
-    if length(parts) ∉ (10, 13)
-        throw(ArgumentError("dmrg_step! returned $(length(parts)) values; expected 10 or 13"))
-    end
-
-    env_block = length(parts) == 13 ? parts[10] : nothing
-    env_tensor_dict = length(parts) == 13 ? parts[11] : nothing
-    env_block_enl = length(parts) == 13 ? parts[12] : nothing
-    env_trmat = length(parts) == 13 ? parts[13] : nothing
-
-    DMRGStepResult(
-        parts[1],
-        parts[2],
-        parts[3],
-        parts[4],
-        parts[5],
-        parts[6],
-        parts[7],
-        parts[8],
-        parts[9],
-        length(parts) == 10 ? parts[10] : nothing,
-        env_block,
-        env_tensor_dict,
-        env_block_enl,
-        env_trmat,
+    return DMRGStepResult(
+        newblock[1],
+        newtensor_dict[1],
+        newblock_enl[1],
+        truncation_error[1],
+        energy,
+        Ψ0,
+        trmat[1],
+        ee[1],
+        es[1],
+        env_calc ? nothing : Sj,
+        env_calc ? newblock[2] : nothing,
+        env_calc ? newtensor_dict[2] : nothing,
+        env_calc ? newblock_enl[2] : nothing,
+        env_calc ? trmat[2] : nothing,
     )
 end
 
+struct DMRGStepResult{B,T,BEnl,ΨT,TrT,EST,SJT,EB,ET,EBEnl,ETrT}
+    block::B
+    tensor_dict::T
+    block_enl::BEnl
+    trerr::Float64
+    energy::Float64
+    Ψ::ΨT
+    trmat::TrT
+    ee::Float64
+    es::EST
+    Sj::SJT
+    env_block::EB
+    env_tensor_dict::ET
+    env_block_enl::EBEnl
+    env_trmat::ETrT
+end
+
 function dmrg_step_result!(args...; kwargs...)
-    _dmrg_step_result(dmrg_step!(args...; kwargs...))
+    dmrg_step!(args...; kwargs...)
 end

--- a/src/step_density.jl
+++ b/src/step_density.jl
@@ -29,6 +29,32 @@ function _empty_density_matrix_vector(engine)
     empty_engine_matrix_vector(engine)
 end
 
+function _syrk!(::Type{<:CPUEngine}, uplo, trans, α, A, β, C)
+    BLAS.syrk!(uplo, trans, α, A, β, C)
+end
+
+function _syrk!(::Type{<:GPUEngine}, uplo, trans, α, A, β, C)
+    CUBLAS.syrk!(uplo, trans, α, A, β, C)
+end
+
+function _density_syev!(::Type{<:CPUEngine}, ρ)
+    LAPACK.syev!('V', 'U', ρ)
+end
+
+function _density_syev!(::Type{<:GPUEngine}, ρ)
+    magma_syevd!('V', 'U', ρ)
+end
+
+function _density_matrix_from_wavefunction!(ρ, Ψ0, fac, trans, engine)
+    for Ψ in Ψ0
+        for J in eachindex(Ψ)
+            _syrk!(engine, 'U', trans, fac, Ψ[J], 1.0, ρ)
+        end
+    end
+    synchronize_engine(engine)
+    return ρ
+end
+
 function _reduced_density_matrices(Ψ0, switch, side::_StepSideContext, dimβ, sys_len, env_len, context::_StepDensityContext)
     (; len, ms) = side
     (; comm, rank, engine) = context
@@ -37,22 +63,8 @@ function _reduced_density_matrices(Ψ0, switch, side::_StepSideContext, dimβ, s
     if switch == 1
         for k in 1 : len
             fac = 1.0 / dimβ[k]
-            if engine <: GPUEngine
-                ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
-                for j in 1 : env_len
-                    for J in eachindex(Ψ0[j, k])
-                        CUBLAS.syrk!('U', 'T', fac, Ψ0[j, k][J], 1.0, ρ)
-                    end
-                end
-                CUDA.synchronize()
-            else
-                ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
-                for j in 1 : env_len
-                    for J in eachindex(Ψ0[j, k])
-                        BLAS.syrk!('U', 'T', fac, Ψ0[j, k][J], 1.0, ρ)
-                    end
-                end
-            end
+            ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
+            _density_matrix_from_wavefunction!(ρ, (Ψ0[j, k] for j in 1 : env_len), fac, 'T', engine)
             MPI.Reduce!(ρ, MPI.SUM, 0, comm)
             if rank == 0
                 push!(ρs, ρ)
@@ -61,22 +73,8 @@ function _reduced_density_matrices(Ψ0, switch, side::_StepSideContext, dimβ, s
     else
         for k in 1 : len
             fac = 1.0 / dimβ[k]
-            if engine <: GPUEngine
-                ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
-                for j in 1 : sys_len
-                    for J in eachindex(Ψ0[k, j])
-                        CUBLAS.syrk!('U', 'N', fac, Ψ0[k, j][J], 1.0, ρ)
-                    end
-                end
-                CUDA.synchronize()
-            else
-                ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
-                for j in 1 : sys_len
-                    for J in eachindex(Ψ0[k, j])
-                        BLAS.syrk!('U', 'N', fac, Ψ0[k, j][J], 1.0, ρ)
-                    end
-                end
-            end
+            ρ = zeros_like_engine(engine, Float64, ms[k], ms[k])
+            _density_matrix_from_wavefunction!(ρ, (Ψ0[k, j] for j in 1 : sys_len), fac, 'N', engine)
             MPI.Reduce!(ρ, MPI.SUM, 0, comm)
             if rank == 0
                 push!(ρs, ρ)
@@ -114,13 +112,7 @@ end
 function _density_eigendecomposition(ρnew, context::_StepDensityContext)
     (; engine) = context
     local λζtemp
-    time_DM = @elapsed begin
-        if engine <: GPUEngine
-            λζtemp = map(ρ -> magma_syevd!('V', 'U', ρ), ρnew)
-        else
-            λζtemp = map(ρ -> LAPACK.syev!('V', 'U', ρ), ρnew)
-        end
-    end
+    time_DM = @elapsed λζtemp = map(ρ -> _density_syev!(engine, ρ), ρnew)
 
     return λζtemp, time_DM
 end
@@ -204,16 +196,10 @@ function _apply_density_matrix_correction!(ρs, switch, side::_StepSideContext, 
         else
             if switch == 1
                 Sx = haskey(sys_tensor_dict_hold, x) ? sys_tensor_dict_hold[x] : sys_tensor_dict[x]
-                Stemp = [[zeros_like_engine(engine, Float64, sys_ms[i], sys_ms[j]) for τ1 in 1 : get(sys_dp[j], sys_βs[i], 0)] for i in eachindex(sys_ms), j in eachindex(sys_ms)]
-                for e in sys_enlarge
-                    @. Stemp[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sx[e.ki, e.kj][e.τ2]
-                end
+                Stemp = _enlarged_spin_tensor(sys_ms, sys_βs, sys_dp, sys_enlarge, Sx, engine)
             else
                 Sx = haskey(env_tensor_dict_hold, x) ? env_tensor_dict_hold[x] : env_tensor_dict[x]
-                Stemp = [[zeros_like_engine(engine, Float64, env_ms[i], env_ms[j]) for τ1 in 1 : get(env_dp[j], env_βs[i], 0)] for i in eachindex(env_ms), j in eachindex(env_ms)]
-                for e in env_enlarge
-                    @. Stemp[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * Sx[e.ki, e.kj][e.τ2]
-                end
+                Stemp = _enlarged_spin_tensor(env_ms, env_βs, env_dp, env_enlarge, Sx, engine)
             end
         end
 

--- a/src/step_lanczos.jl
+++ b/src/step_lanczos.jl
@@ -50,11 +50,7 @@ function _step_spin_operator(x, conn, connS, ms, βs, dp, enlarging, tensor_dict
     if x == conn
         return connS
     elseif x > 0
-        spin = [[zeros_like_engine(engine, Float64, ms[i], ms[j]) for τ1 in 1 : get(dp[j], βs[i], 0)] for i in eachindex(ms), j in eachindex(ms)]
-        for e in enlarging
-            @. spin[e.i, e.j][e.τ1][e.range_i, e.range_j] += e.coeff * tensor_dict_hold[x][e.ki, e.kj][e.τ2]
-        end
-        return spin
+        return _enlarged_spin_tensor(ms, βs, dp, enlarging, tensor_dict_hold[x], engine)
     end
 
     return nothing

--- a/src/step_types.jl
+++ b/src/step_types.jl
@@ -34,157 +34,157 @@ struct BlockEnlarging
     coeff::Float64
     τ1::Int
     τ2::Int
-    range_i::UnitRange
-    range_j::UnitRange
+    range_i::UnitRange{Int}
+    range_j::UnitRange{Int}
     i::Int
     j::Int
     ki::Int
     kj::Int
 end
 
-struct _StepSideContext
+struct _StepSideContext{MS,B,D,BT,BET}
     len::Int
-    ms
-    betas
-    dp
+    ms::MS
+    betas::B
+    dp::D
     conn::Int
     label::Symbol
-    block
-    block_enl
+    block::BT
+    block_enl::BET
 end
 
-struct _StepLanczosContext
+struct _StepLanczosContext{CommT,E,H1,BondsT,SysConnT,EnvConnT,MST,BetaT,DPT,EnlargeT,SysTensorT,EnvTensorT,H2T,OMT}
     target::Int
-    comm
+    comm::CommT
     rank::Int
-    engine
+    engine::Type{E}
     alg::Symbol
-    superblock_H1
-    bonds_hold
+    superblock_H1::H1
+    bonds_hold::BondsT
     x_conn::Int
     y_conn::Int
-    sys_connS
-    env_connS
-    sys_ms
-    env_ms
-    sys_βs
-    env_βs
-    sys_dp
-    env_dp
-    sys_enlarge
-    env_enlarge
-    sys_tensor_dict_hold
-    env_tensor_dict_hold
-    superblock_H2
-    OM
+    sys_connS::SysConnT
+    env_connS::EnvConnT
+    sys_ms::MST
+    env_ms::MST
+    sys_βs::BetaT
+    env_βs::BetaT
+    sys_dp::DPT
+    env_dp::DPT
+    sys_enlarge::EnlargeT
+    env_enlarge::EnlargeT
+    sys_tensor_dict_hold::SysTensorT
+    env_tensor_dict_hold::EnvTensorT
+    superblock_H2::H2T
+    OM::OMT
     sys_len::Int
     env_len::Int
     Ncpu::Int
 end
 
-struct _StepDensityContext
-    comm
+struct _StepDensityContext{CommT,E}
+    comm::CommT
     rank::Int
     Ncpu::Int
-    engine
+    engine::Type{E}
     α::Float64
     m::Int
     ES_max::Float64
     noisy::Bool
 end
 
-struct _StepMeasurementContext
-    SiSj
+struct _StepMeasurementContext{SiSjT,SysConnT,EnvConnT,SysTensorT,EnvTensorT,SysTensorHoldT,EnvTensorHoldT,BetaT,DPT,MST,EnlargeT,H2T,OMT,CommT,E}
+    SiSj::SiSjT
     Ly::Int
     x_conn::Int
     y_conn::Int
-    sys_connS
-    env_connS
+    sys_connS::SysConnT
+    env_connS::EnvConnT
     sys_len::Int
     env_len::Int
-    sys_tensor_dict
-    env_tensor_dict
-    sys_tensor_dict_hold
-    env_tensor_dict_hold
-    sys_αs
-    env_αs
-    sys_βs
-    env_βs
-    sys_dp
-    env_dp
-    sys_ms
-    env_ms
-    sys_enlarge
-    env_enlarge
-    superblock_H2
-    OM
-    comm
+    sys_tensor_dict::SysTensorT
+    env_tensor_dict::EnvTensorT
+    sys_tensor_dict_hold::SysTensorHoldT
+    env_tensor_dict_hold::EnvTensorHoldT
+    sys_αs::BetaT
+    env_αs::BetaT
+    sys_βs::BetaT
+    env_βs::BetaT
+    sys_dp::DPT
+    env_dp::DPT
+    sys_ms::MST
+    env_ms::MST
+    sys_enlarge::EnlargeT
+    env_enlarge::EnlargeT
+    superblock_H2::H2T
+    OM::OMT
+    comm::CommT
     rank::Int
     Ncpu::Int
-    engine
+    engine::Type{E}
     correlation::Symbol
     margin::Int
     lattice::Symbol
 end
 
-struct _StepBlockContext
+struct _StepBlockContext{CommT,TablesT,E}
     Ly::Int
     widthmax::Int
     signfactor::Float64
-    comm
+    comm::CommT
     rank::Int
     Ncpu::Int
-    tables
+    tables::TablesT
     on_the_fly::Bool
-    engine
+    engine::Type{E}
     lattice::Symbol
 end
 
-struct _StepCorrectionContext
-    superblock_bonds
-    sys_connS
-    env_connS
-    sys_enl
-    env_enl
+struct _StepCorrectionContext{BondsT,SysConnT,EnvConnT,SysEnlT,EnvEnlT,SysTensorHoldT,EnvTensorHoldT,SysTensorT,EnvTensorT,MST,DPT,BetaT,EnlargeT,E}
+    superblock_bonds::BondsT
+    sys_connS::SysConnT
+    env_connS::EnvConnT
+    sys_enl::SysEnlT
+    env_enl::EnvEnlT
     x_conn::Int
     y_conn::Int
-    sys_tensor_dict_hold
-    env_tensor_dict_hold
-    sys_tensor_dict
-    env_tensor_dict
-    sys_ms
-    env_ms
-    sys_dp
-    env_dp
-    sys_βs
-    env_βs
-    sys_enlarge
-    env_enlarge
-    engine
+    sys_tensor_dict_hold::SysTensorHoldT
+    env_tensor_dict_hold::EnvTensorHoldT
+    sys_tensor_dict::SysTensorT
+    env_tensor_dict::EnvTensorT
+    sys_ms::MST
+    env_ms::MST
+    sys_dp::DPT
+    env_dp::DPT
+    sys_βs::BetaT
+    env_βs::BetaT
+    sys_enlarge::EnlargeT
+    env_enlarge::EnlargeT
+    engine::Type{E}
 end
 
-struct _StepWorkspace
-    sys_αs
-    env_αs
-    sys_βs
-    env_βs
-    sys_ms
-    env_ms
+struct _StepWorkspace{SysAlphaT,EnvAlphaT,SysBetaT,EnvBetaT,SysMST,EnvMST,BondsT,HoldBondsT,SysDPT,EnvDPT,SysEnlargeT,EnvEnlargeT,OMT,H1T,H2T,SysConnT,EnvConnT,SysTensorT,EnvTensorT}
+    sys_αs::SysAlphaT
+    env_αs::EnvAlphaT
+    sys_βs::SysBetaT
+    env_βs::EnvBetaT
+    sys_ms::SysMST
+    env_ms::EnvMST
     sys_len::Int
     env_len::Int
-    superblock_bonds
-    bonds_hold
+    superblock_bonds::BondsT
+    bonds_hold::HoldBondsT
     x_conn::Int
     y_conn::Int
-    sys_dp
-    env_dp
-    sys_enlarge
-    env_enlarge
-    OM
-    superblock_H1
-    superblock_H2
-    sys_connS
-    env_connS
-    sys_tensor_dict_hold
-    env_tensor_dict_hold
+    sys_dp::SysDPT
+    env_dp::EnvDPT
+    sys_enlarge::SysEnlargeT
+    env_enlarge::EnvEnlargeT
+    OM::OMT
+    superblock_H1::H1T
+    superblock_H2::H2T
+    sys_connS::SysConnT
+    env_connS::EnvConnT
+    sys_tensor_dict_hold::SysTensorT
+    env_tensor_dict_hold::EnvTensorT
 end

--- a/src/step_workspace.jl
+++ b/src/step_workspace.jl
@@ -152,10 +152,10 @@ function _connection_tensor(block_enl, conn, held_sites)
 end
 
 function _prepare_step_workspace(sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, lattice, ::Val{Nc}) where Nc
-    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
-    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
-    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
-    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
     sys_ms = MPI.bcast(sys_enl.mβ_list, 0, comm)::Vector{Int}
     env_ms = MPI.bcast(env_enl.mβ_list, 0, comm)::Vector{Int}
     sys_mαβ = MPI.bcast(sys_enl.mαβ, 0, comm)::Matrix{Int}

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -9,10 +9,10 @@ function eig_prediction(Ψ0, sys_label, sys_enl::EnlargedBlock{Nc}, env_enl::Enl
     env_mαβ = MPI.bcast(env_enl.mαβ, 0, comm)::Matrix{Int}
     cum_sys_mαβ = vcat(zeros(Int, 1, size(sys_mαβ, 2)), cumsum(sys_mαβ, dims = 1))
     cum_env_mαβ = vcat(zeros(Int, 1, size(env_mαβ, 2)), cumsum(env_mαβ, dims = 1))
-    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
-    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
-    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
-    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    sys_αs = MPI.bcast(sys_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    sys_βs = MPI.bcast(sys_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    env_αs = MPI.bcast(env_enl.α_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    env_βs = MPI.bcast(env_enl.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
     OM = OM_matrix(sys_βs, env_αs, γirrep)
     sys_mα = MPI.bcast(sys_enl.mα_list, 0, comm)::Vector{Int}
     sys_mβ = MPI.bcast(sys_enl.mβ_list, 0, comm)::Vector{Int}
@@ -95,8 +95,8 @@ end
 function _wavefunction_reverse(Ψ0, sys_label, sys, env, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Nc)
     γirrep = γ_list[mod1(sys.length + env.length, Nc)]
 
-    sys_βs = MPI.bcast(sys.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
-    env_βs = MPI.bcast(env.β_list, 0, comm)::Vector{<:SUNIrrep{Nc}}
+    sys_βs = MPI.bcast(sys.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
+    env_βs = MPI.bcast(env.β_list, 0, comm)::Vector{SUNIrrep{Nc}}
 
     Ψ0_new = [[zeros_like_engine(engine, Float64, size(Ψ0[i, j][J], 2), size(Ψ0[i, j][J], 1)) for J in 1 : length(Ψ0[i, j])] for j in 1 : size(Ψ0, 2), i in 1 : size(Ψ0, 1)]
 

--- a/test/test_finite_helpers.jl
+++ b/test/test_finite_helpers.jl
@@ -67,8 +67,8 @@
     end
 end
 
-@testset "DMRG step result adapter" begin
-    step = SUNDMRG._dmrg_step_result(ntuple(identity, 10))
+@testset "DMRG step result" begin
+    step = SUNDMRG.DMRGStepResult(1, 2, 3, 4.0, 5.0, 6, 7, 8.0, 9, 10, nothing, nothing, nothing, nothing)
     @test step.block == 1
     @test step.es == 9
     @test step.Sj == 10
@@ -77,7 +77,7 @@ end
     @test step.env_block_enl === nothing
     @test step.env_trmat === nothing
 
-    env_step = SUNDMRG._dmrg_step_result(ntuple(identity, 13))
+    env_step = SUNDMRG.DMRGStepResult(1, 2, 3, 4.0, 5.0, 6, 7, 8.0, 9, nothing, 10, 11, 12, 13)
     @test env_step.block == 1
     @test env_step.es == 9
     @test env_step.Sj === nothing
@@ -85,6 +85,4 @@ end
     @test env_step.env_tensor_dict == 11
     @test env_step.env_block_enl == 12
     @test env_step.env_trmat == 13
-
-    @test_throws ArgumentError SUNDMRG._dmrg_step_result((1, 2, 3))
 end


### PR DESCRIPTION
## Summary

- Bump the package version to v1.4.5.
- Refactor `dmrg_step!` to return `DMRGStepResult` directly instead of routing through tuple adapters.
- Add typed state/context structs for finite runs, sweep state, step contexts, and DMRG step results.
- Reduce duplicated CPU/GPU and spin-tensor logic with helper functions and dispatch.
- Consolidate duplicated finite/sweep result recording helpers.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test()'`
- Result: `SUNDMRG CPU-only pure tests | 229 229`, tests passed.