### PR TITLE
[codex] Improve type stability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.4.5"
+version = "1.4.6"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/src/api.jl
+++ b/src/api.jl
@@ -22,7 +22,7 @@ function run_DMRG end
 
 _dmrg_schedule(m::Int) = (m, 0.0)
 _dmrg_schedule(m::Tuple{Int, Float64}) = m
-_dmrg_schedule_list(ms::AbstractVector) = _dmrg_schedule.(ms)
+_dmrg_schedule_list(ms::AbstractVector) = Tuple{Int, Float64}[_dmrg_schedule(m) for m in ms]
 
 function run_DMRG(model::HeisenbergModelSU{Nc}, lat::SquareLattice, m_warmup::Union{Int, Tuple{Int, Float64}}, m_sweep_list::AbstractVector, m_cooldown::Union{Int, Tuple{Int, Float64}}, engine::Type{<:Engine}; kwargs...) where Nc
     _run_DMRG(model, :square, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)

--- a/src/block.jl
+++ b/src/block.jl
@@ -1,10 +1,17 @@
+const ScalarDictCPU = Dict{Symbol, Vector{Matrix{Float64}}}
+const TensorMatrixCPU = Matrix{Vector{Matrix{Float64}}}
+const TensorDictCPU = Dict{Int, TensorMatrixCPU}
+const ScalarDictGPU = Dict{Symbol, Vector{CuMatrix{Float64}}}
+const TensorMatrixGPU = Matrix{Vector{CuMatrix{Float64}}}
+const TensorDictGPU = Dict{Int, TensorMatrixGPU}
+
 struct Block{Nc}
     length::Int
     bonds::Vector{Tuple{Int, Int}}
     β_list::Vector{SUNIrrep{Nc}}
     mβ_list_old::Vector{Int}
     mβ_list::Vector{Int}
-    scalar_dict::Dict{Symbol, Vector{Matrix{Float64}}}
+    scalar_dict::ScalarDictCPU
 end
 
 abstract type EnlargedBlock{Nc} end
@@ -17,8 +24,8 @@ struct EnlargedBlockCPU{Nc} <: EnlargedBlock{Nc}
     β_list::Vector{SUNIrrep{Nc}}
     mβ_list::Vector{Int}
     mαβ::Matrix{Int}
-    scalar_dict::Dict{Symbol, Vector{Matrix{Float64}}}
-    tensor_dict::Dict{Int, Matrix{Vector{Matrix{Float64}}}}
+    scalar_dict::ScalarDictCPU
+    tensor_dict::TensorDictCPU
 end
 
 struct EnlargedBlockGPU{Nc} <: EnlargedBlock{Nc}
@@ -29,8 +36,8 @@ struct EnlargedBlockGPU{Nc} <: EnlargedBlock{Nc}
     β_list::Vector{SUNIrrep{Nc}}
     mβ_list::Vector{Int}
     mαβ::Matrix{Int}
-    scalar_dict::Dict{Symbol, Vector{CuMatrix{Float64}}}
-    tensor_dict::Dict{Int, Matrix{Vector{CuMatrix{Float64}}}}
+    scalar_dict::ScalarDictGPU
+    tensor_dict::TensorDictGPU
 end
 
 function _build_spin_tensor(Nc, αs, βs, mαβ, αβmatrix, cum_mαβ, tables, on_the_fly)
@@ -47,7 +54,7 @@ function _build_spin_tensor(Nc, αs, βs, mαβ, αβmatrix, cum_mαβ, tables, 
             rtn = zeros(ms[i], ms[j])
             for k in 1 : lenα
                 if αβmatrix[k, i] && αβmatrix[k, j]
-                    coeff = on_the_fly ? on_the_fly_calc2(Nc, (αs[k], βs[j], βs[i])) : tables[2][αs[k], βs[j], βs[i]]
+                    coeff = _on_the_fly(on_the_fly) ? on_the_fly_calc2(Nc, (αs[k], βs[j], βs[i])) : tables[2][αs[k], βs[j], βs[i]]
                     for l in 1 : mαβ[k, i]
                         rtn[cum_mαβ[k, i] + l, cum_mαβ[k, j] + l] = fac * coeff[τ1]
                     end
@@ -77,7 +84,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
         funda = fundamentalirrep(Val(Nc))
 
         dest = map(α -> unique(keys(directproduct(α, funda))), αs)
-        βs = sort!(filter!(β -> on_the_fly || weight(β)[1] <= widthmax, union(dest[block.mβ_list .> 0]...)))
+        βs = sort!(filter!(β -> _on_the_fly(on_the_fly) || weight(β)[1] <= widthmax, union(dest[block.mβ_list .> 0]...)))
         αβmatrix = [β ∈ d for d in dest, β in βs]
         mαβ = Diagonal(block.mβ_list) * αβmatrix
         @. αβmatrix = mαβ > 0
@@ -115,7 +122,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
     if rank == 0
         y1 = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(block.length, 2Ly))
         y2 = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(block.length + 1, 2Ly))
-        zlist = block.length == 0 ? Int[] : ((block.length < Ly || y1 == y2 || (lattice == :honeycombZC && (mod1(block.length + 1, 2Ly) <= Ly ? iseven(y2) : isodd(y2)))) ? [y1] : [y1, y2])
+        zlist = block.length == 0 ? Int[] : ((block.length < Ly || y1 == y2 || (_is_honeycomb_zc(lattice) && (mod1(block.length + 1, 2Ly) <= Ly ? iseven(y2) : isodd(y2)))) ? [y1] : [y1, y2])
         if (block.length + 1) % Ly == 0
             if y2 == 1
                 push!(zlist, Ly)
@@ -134,7 +141,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
                             if αβmatrix[j, k]
                                 o1 = length(block_tensor_dict[z][i, j])
                                 if o1 > 0
-                                    coeff = on_the_fly ? on_the_fly_calc3(Nc, (αs[j], βs[k], αs[i])) : tables[3][αs[j], βs[k], αs[i]]
+                                    coeff = _on_the_fly(on_the_fly) ? on_the_fly_calc3(Nc, (αs[j], βs[k], αs[i])) : tables[3][αs[j], βs[k], αs[i]]
                                     for τ1 in 1 : o1
                                         temp2 = fac2 * coeff[τ1]
                                         temp3 = block_tensor_dict[z][i, j][τ1]
@@ -150,7 +157,7 @@ function enlarge_block(block::Block{Nc}, block_tensor_dict, Ly, widthmax, signfa
         end
         if block.length > 0
             push!(bonds, (block.length, block.length + 1))
-            if !(block.length < Ly || y1 == y2 || (lattice == :honeycombZC && (mod1(block.length + 1, 2Ly) <= Ly ? iseven(y2) : isodd(y2))))
+            if !(block.length < Ly || y1 == y2 || (_is_honeycomb_zc(lattice) && (mod1(block.length + 1, 2Ly) <= Ly ? iseven(y2) : isodd(y2))))
                 push!(bonds, (block.length + 2 - 2mod1(block.length + 1, Ly), block.length + 1))
             end
             if (block.length + 1) % Ly == 0
@@ -183,11 +190,11 @@ function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_l
     env_tensor_dict = empty_engine_tensor_dict(engine)
     y_conn = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(env.length, 2Ly))
     for y in 1 : min(env.length, Ly)
-        if lattice != :honeycombZC || y == y_conn || ((mod1(env.length, 2Ly) <= Ly) ? y == 1 : y == Ly) || (y <= y_conn ? iseven(y) : isodd(y))
+        if !_is_honeycomb_zc(lattice) || y == y_conn || ((mod1(env.length, 2Ly) <= Ly) ? y == 1 : y == Ly) || (y <= y_conn ? iseven(y) : isodd(y))
             if rank == 0
-                spin = load_tensor(storage, env_label, env.length, y)
-
-                if isnothing(spin)
+                if has_tensor(storage, env_label, env.length, y)
+                    spin = take_tensor!(storage, env_label, env.length, y)
+                else
                     z = max(2Ly * ((env.length - y) ÷ 2Ly) + y, 2Ly * ((env.length - (1 - y)) ÷ 2Ly) + 1 - y)
 
                     env_old = load_block(storage, env_label, z - 1)::Block{Nc}
@@ -198,7 +205,7 @@ function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_l
                     adjoint = adjointirrep(Val(Nc))
             
                     dest = map(α -> unique(keys(directproduct(α, funda))), αs)
-                    βs = sort!(filter!(β -> on_the_fly || weight(β)[1] <= widthmax, union(dest[env_old.mβ_list .> 0]...)))
+                    βs = sort!(filter!(β -> _on_the_fly(on_the_fly) || weight(β)[1] <= widthmax, union(dest[env_old.mβ_list .> 0]...)))
                     αβmatrix = [β ∈ d for d in dest, β in βs]
                     mαβ = Diagonal(env_old.mβ_list) * αβmatrix
                     @. αβmatrix = mαβ > 0
@@ -217,16 +224,12 @@ function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_l
                     Sold = map(k -> isempty(Snew[k...]) ? empty_engine_matrix_vector(engine) : [env_trmat[k[1]]' * (M * env_trmat[k[2]]) for M in Snew[k...]], [(ki, kj) for ki in 1 : lennew, kj in 1 : lennew])
 
                     for x in z + 1 : env.length
-                        if engine <: GPUEngine
-                            save_tensor(storage, env_label, x - 1, y, [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew])
-                        else
-                            save_tensor(storage, env_label, x - 1, y, deepcopy(Sold))
-                        end
+                        save_tensor(storage, env_label, x - 1, y, host_tensor_for_save(engine, Sold, lennew))
 
                         αs = copy(βs)
                         lenα = length(αs)
                         dest = map(α -> Set(keys(directproduct(α, funda))), αs)
-                        βs = sort!(filter!(β -> on_the_fly || weight(β)[1] <= widthmax, collect(union(dest[ms .> 0]...))))
+                        βs = sort!(filter!(β -> _on_the_fly(on_the_fly) || weight(β)[1] <= widthmax, collect(union(dest[ms .> 0]...))))
                         αβmatrix = [β ∈ d for d in dest, β in βs]
                         mαβ = Diagonal(ms) * αβmatrix
                         @. αβmatrix = mαβ > 0
@@ -242,7 +245,7 @@ function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_l
                                 rtn = zeros_like_engine(engine, Float64, ms[i], ms[j])
                                 for ki in findall(αβmatrix[:, i]), kj in findall(αβmatrix[:, j])
                                     if haskey(dp2[kj], αs[ki])
-                                        coeff = on_the_fly ? on_the_fly_calc1(Nc, (αs[kj], βs[j], αs[ki], βs[i])) : tables[1][αs[kj], βs[j], αs[ki], βs[i]]
+                                        coeff = _on_the_fly(on_the_fly) ? on_the_fly_calc1(Nc, (αs[kj], βs[j], αs[ki], βs[i])) : tables[1][αs[kj], βs[j], αs[ki], βs[i]]
                                         for τ2 in 1 : size(coeff, 1)
                                             @. rtn[cum_mαβ[ki, i] + 1 : cum_mαβ[ki + 1, i], cum_mαβ[kj, j] + 1 : cum_mαβ[kj + 1, j]] += coeff[τ2, τ1] * Sold[ki, kj][τ2]
                                         end
@@ -256,14 +259,10 @@ function spin_operators!(storage::AbstractInternalStorage, env::Block{Nc}, env_l
         
                         lennew = length(env_trmat)
                         ms = map(k -> size(env_trmat[k], 2), 1 : lennew)
-                        Sold = map(k -> isempty(Snew[k...]) ? Matrix{Float64}[] : [env_trmat[k[1]]' * (M * env_trmat[k[2]]) for M in Snew[k...]], [(ki, kj) for ki in 1 : lennew, kj in 1 : lennew])
+                        Sold = map(k -> isempty(Snew[k...]) ? empty_engine_matrix_vector(engine) : [env_trmat[k[1]]' * (M * env_trmat[k[2]]) for M in Snew[k...]], [(ki, kj) for ki in 1 : lennew, kj in 1 : lennew])
                     end
 
-                    if engine <: GPUEngine
-                        spin = [to_host_array.(Sold[ki, kj]) for ki in 1 : lennew, kj in 1 : lennew]
-                    else
-                        spin = Sold
-                    end
+                    spin = host_tensor_for_save(engine, Sold, lennew)
                 end
 
                 env_tensor_dict[y] = spin

--- a/src/engine_utils.jl
+++ b/src/engine_utils.jl
@@ -3,52 +3,32 @@
 
 Allocate a zero-filled array with element type `T` and shape `dims`, matching the backend implied by `engine`.
 """
-function zeros_like_engine(engine, T, dims...)
-    if engine <: GPUEngine
-        CUDA.zeros(T, dims...)
-    else
-        zeros(T, dims...)
-    end
-end
+zeros_like_engine(::Type{<:CPUEngine}, T, dims...) = zeros(T, dims...)
+zeros_like_engine(::Type{<:GPUEngine}, T, dims...) = CUDA.zeros(T, dims...)
 
 """
     to_engine_array(engine, x)
 
 Convert `x` to an engine-native array representation.
 """
-function to_engine_array(engine, x)
-    if engine <: GPUEngine
-        CuArray(x)
-    else
-        x
-    end
-end
+to_engine_array(::Type{<:CPUEngine}, x) = x
+to_engine_array(::Type{<:GPUEngine}, x) = CuArray(x)
 
 """
     to_host_array(x)
 
 Convert an engine array back to a host `Array` when needed.
 """
-function to_host_array(x)
-    if x isa CuArray
-        Array(x)
-    else
-        x
-    end
-end
+to_host_array(x) = x
+to_host_array(x::CuArray) = Array(x)
 
 """
     engine_matrix_type(engine)
 
 Return the concrete matrix type used by the selected engine for `Float64` data.
 """
-function engine_matrix_type(engine)
-    if engine <: GPUEngine
-        CuMatrix{Float64}
-    else
-        Matrix{Float64}
-    end
-end
+engine_matrix_type(::Type{<:CPUEngine}) = Matrix{Float64}
+engine_matrix_type(::Type{<:GPUEngine}) = CuMatrix{Float64}
 
 empty_engine_matrix_vector(engine) = engine_matrix_type(engine)[]
 
@@ -64,9 +44,15 @@ function empty_engine_tensor_matrices(engine, n)
     [empty_engine_tensor_matrix(engine) for _ in 1 : n]
 end
 
-function synchronize_engine(engine)
-    if engine <: GPUEngine
-        CUDA.synchronize()
-    end
+synchronize_engine(::Type{<:CPUEngine}) = nothing
+
+function synchronize_engine(::Type{<:GPUEngine})
+    CUDA.synchronize()
     return nothing
 end
+
+host_tensor_for_save(::Type{<:CPUEngine}, tensor, len) = deepcopy(tensor)
+host_tensor_for_save(::Type{<:GPUEngine}, tensor, len) = [to_host_array.(tensor[ki, kj]) for ki in 1 : len, kj in 1 : len]
+
+engine_tensor_from_host(::Type{<:CPUEngine}, tensor, len) = tensor
+engine_tensor_from_host(engine::Type{<:GPUEngine}, tensor, len) = [to_engine_array.(Ref(engine), tensor[i, j]) for i in 1 : len, j in 1 : len]

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -4,7 +4,7 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
 
     did_init = false
     runtime_initialized = false
-    storage = nothing
+    runtime_finalized = Ref(false)
     rank = 0
     if manage_mpi
         did_init = init_DMRG!()
@@ -16,12 +16,24 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         comm, rank, Ncpu = _comm_context()
         on_the_fly, mirror, γ_type, γ_list, N, signfactor = _init_runtime_and_engine(engine, lattice, Lx, Ly, Nc, rank, Ncpu)
         runtime_initialized = true
-        config = _FiniteRunConfig(lattice, Lx, Ly, N, Nc, m_warmup, m_sweep_list, m_cooldown, target, widthmax, tables, fileio, scratch, ES_max, tol_energy, tol_EE, correlation, margin, alg, verbose)
+        config = _FiniteRunConfig(Val(lattice), Lx, Ly, N, Nc, m_warmup, m_sweep_list, m_cooldown, target, widthmax, tables, Val(fileio), scratch, ES_max, tol_energy, tol_EE, Val(correlation), margin, Val(alg), verbose)
         runtime = _FiniteRuntime(engine, comm, rank, Ncpu, on_the_fly, mirror, γ_type, γ_list, signfactor)
 
-        state = _init_state(config, runtime)
-        storage = state.storage
+        return _run_DMRG_impl(config, runtime, runtime_finalized, Val(Nc))
+    finally
+        if runtime_initialized && !runtime_finalized[]
+            _finalize_runtime!(engine, nothing, rank)
+        end
+        if manage_mpi && did_init
+            finalize_DMRG!()
+        end
+    end
+end
 
+function _run_DMRG_impl(config::_FiniteRunConfig, runtime::_FiniteRuntime, runtime_finalized, ::Val{Nc}) where Nc
+    state = _init_state(config, runtime)
+
+    try
         _warmup_phase!(state, config, runtime)
 
         growth = _growth_phase!(state, config, runtime)
@@ -37,13 +49,9 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
             map!(x -> 0.5x, values(state.SiSj))
         end
 
-        return rank, rank == 0 ? DMRGOutput(state.m_list, state.errors, state.energies, state.EEs, state.EE, ESrtn, state.SiSj) : nothing
+        return runtime.rank, runtime.rank == 0 ? DMRGOutput(state.m_list, state.errors, state.energies, state.EEs, state.EE, ESrtn, state.SiSj) : nothing
     finally
-        if runtime_initialized
-            _finalize_runtime!(engine, storage, rank)
-        end
-        if manage_mpi && did_init
-            finalize_DMRG!()
-        end
+        _finalize_runtime!(runtime.engine, state.storage, runtime.rank)
+        runtime_finalized[] = true
     end
 end

--- a/src/finite_config.jl
+++ b/src/finite_config.jl
@@ -1,7 +1,7 @@
 const _DMRGSchedule = Tuple{Int, Float64}
 
-struct _FiniteRunConfig{L,T,S,C,A}
-    lattice::L
+struct _FiniteRunConfig{L,T,F,S,C,A}
+    lattice::Val{L}
     Lx::Int
     Ly::Int
     N::Int
@@ -12,7 +12,7 @@ struct _FiniteRunConfig{L,T,S,C,A}
     target::Int
     widthmax::Int
     tables::T
-    fileio::Bool
+    fileio::Val{F}
     scratch::S
     ES_max::Float64
     tol_energy::Float64

--- a/src/finite_phases.jl
+++ b/src/finite_phases.jl
@@ -1,4 +1,4 @@
-function _record_step_result!(m_list, errors, energies, EEs, m, result::DMRGStepResult)
+function _record_step_result!(m_list, errors, energies, EEs, m, result::AbstractDMRGStepResult)
     push!(m_list, m)
     push!(errors, result.trerr)
     push!(energies, result.energy)
@@ -6,7 +6,7 @@ function _record_step_result!(m_list, errors, energies, EEs, m, result::DMRGStep
     return result.es
 end
 
-function _apply_left_step_result!(state::_FiniteState, result::DMRGStepResult)
+function _apply_left_step_result!(state::_FiniteState, result::AbstractDMRGStepResult)
     state.blockL = result.block
     state.blockL_tensor_dict = result.tensor_dict
     state.blockL_enl = result.block_enl
@@ -15,7 +15,7 @@ function _apply_left_step_result!(state::_FiniteState, result::DMRGStepResult)
     return result.es
 end
 
-function _apply_mirror_env_result!(state::_FiniteState, result::DMRGStepResult, config::_FiniteRunConfig, runtime::_FiniteRuntime)
+function _apply_mirror_env_result!(state::_FiniteState, result::DMRGStepResultWithEnv, config::_FiniteRunConfig, runtime::_FiniteRuntime)
     (; widthmax, tables) = config
     (; comm, rank, Ncpu, on_the_fly, γ_list, engine) = runtime
 
@@ -67,57 +67,11 @@ function _init_state(config::_FiniteRunConfig, runtime::_FiniteRuntime)
     trmat_table = Dict{Tuple{Symbol, Int}, Vector{Matrix{Float64}}}()
 
     if isroot(runtime)
-        if verbose
-            root_println(runtime, repeat("-", 60))
-            root_println(runtime, "SU($Nc) DMRG simulation on the $Lx x $Ly $lattice lattice cylinder:")
-            if on_the_fly
-                root_println(runtime, "All representations are used in the calculation.")
-            else
-                irreps = irreplist(Nc, widthmax)
-                root_println(runtime, length(irreps), " irreps from ", weight(first(irreps)), " to ", weight(last(irreps)), " are used in the calculation.")
-            end
-            root_println(runtime, target == 0 ? "The ground state" : "The excited state #$target", " will be calculated.")
-            root_println(runtime, repeat("-", 60))
-        end
-
-        storage = init_internal_storage(fileio, scratch, block_table, trmat_table, tensor_table, rank)
-
-        blockL = Block(0, Tuple{Int, Int}[], [trivialirrep(Val(Nc))], [1], [1], Dict{Symbol, Vector{Matrix{Float64}}}(:H => [zeros(1, 1)]))
-        blockL_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
-        trmatL = [to_engine_array(engine, diagm([1.0]))]
-
-        if !mirror
-            blockR = Block(0, Tuple{Int, Int}[], [trivialirrep(Val(Nc))], [1], [1], Dict{Symbol, Vector{Matrix{Float64}}}(:H => [zeros(1, 1)]))
-            blockR_tensor_dict = Dict{Int, Matrix{Vector{Matrix{Float64}}}}()
-            trmatR = [to_engine_array(engine, diagm([1.0]))]
-        else
-            blockR = blockL
-            blockR_tensor_dict = blockL_tensor_dict
-            trmatR = trmatL
-        end
-
-        _save_edge_blocks!(storage, mirror, blockL, trmatL, blockR, trmatR, runtime)
-
-        if verbose
-            root_println(runtime, "#")
-            root_println(runtime, "# Warming up with (m, α) = ", m_warmup)
-            root_println(runtime, "#")
-        end
+        storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR =
+            _init_root_state_edges(config, runtime, block_table, trmat_table, tensor_table, Val(Nc))
     else
-        storage = init_internal_storage(fileio, scratch, block_table, trmat_table, tensor_table, rank)
-        blockL = Block(0, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
-        blockL_tensor_dict = empty_engine_tensor_dict(engine)
-        trmatL = empty_engine_matrix_vector(engine)
-
-        if !mirror
-            blockR = Block(0, Tuple{Int, Int}[], γ_type[], Int[], Int[], Dict{Symbol, Vector{Matrix{Float64}}}())
-            blockR_tensor_dict = empty_engine_tensor_dict(engine)
-            trmatR = empty_engine_matrix_vector(engine)
-        else
-            blockR = blockL
-            blockR_tensor_dict = blockL_tensor_dict
-            trmatR = empty_engine_matrix_vector(engine)
-        end
+        storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR =
+            _init_worker_state_edges(config, runtime, block_table, trmat_table, tensor_table, Val(Nc))
     end
 
     blockL_enl = enlarge_block(blockL, blockL_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
@@ -148,6 +102,70 @@ function _init_state(config::_FiniteRunConfig, runtime::_FiniteRuntime)
         trmatR,
         Ψ,
     )
+end
+
+function _init_root_state_edges(config::_FiniteRunConfig, runtime::_FiniteRuntime, block_table, trmat_table, tensor_table, ::Val{Nc}) where Nc
+    (; lattice, Lx, Ly, target, m_warmup, widthmax, fileio, scratch, verbose) = config
+    (; engine, on_the_fly, mirror, rank) = runtime
+
+    if verbose
+        root_println(runtime, repeat("-", 60))
+        root_println(runtime, "SU($Nc) DMRG simulation on the $Lx x $Ly $(_lattice_name(lattice)) lattice cylinder:")
+        if _on_the_fly(on_the_fly)
+            root_println(runtime, "All representations are used in the calculation.")
+        else
+            irreps = irreplist(Nc, widthmax)
+            root_println(runtime, length(irreps), " irreps from ", weight(first(irreps)), " to ", weight(last(irreps)), " are used in the calculation.")
+        end
+        root_println(runtime, target == 0 ? "The ground state" : "The excited state #$target", " will be calculated.")
+        root_println(runtime, repeat("-", 60))
+    end
+
+    storage = init_internal_storage(fileio, scratch, block_table, trmat_table, tensor_table, rank)
+    blockL = Block(0, Tuple{Int, Int}[], [trivialirrep(Val(Nc))], [1], [1], ScalarDictCPU(:H => [zeros(1, 1)]))
+    blockL_tensor_dict = TensorDictCPU()
+    trmatL = [to_engine_array(engine, diagm([1.0]))]
+
+    if !mirror
+        blockR = Block(0, Tuple{Int, Int}[], [trivialirrep(Val(Nc))], [1], [1], ScalarDictCPU(:H => [zeros(1, 1)]))
+        blockR_tensor_dict = TensorDictCPU()
+        trmatR = [to_engine_array(engine, diagm([1.0]))]
+    else
+        blockR = blockL
+        blockR_tensor_dict = blockL_tensor_dict
+        trmatR = trmatL
+    end
+
+    _save_edge_blocks!(storage, mirror, blockL, trmatL, blockR, trmatR, runtime)
+
+    if verbose
+        root_println(runtime, "#")
+        root_println(runtime, "# Warming up with (m, α) = ", m_warmup)
+        root_println(runtime, "#")
+    end
+
+    return storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR
+end
+
+function _init_worker_state_edges(config::_FiniteRunConfig, runtime::_FiniteRuntime, block_table, trmat_table, tensor_table, ::Val{Nc}) where Nc
+    (; fileio, scratch) = config
+    (; engine, mirror, γ_type, rank) = runtime
+    storage = init_internal_storage(fileio, scratch, block_table, trmat_table, tensor_table, rank)
+    blockL = Block(0, Tuple{Int, Int}[], γ_type[], Int[], Int[], ScalarDictCPU())
+    blockL_tensor_dict = empty_engine_tensor_dict(engine)
+    trmatL = empty_engine_matrix_vector(engine)
+
+    if !mirror
+        blockR = Block(0, Tuple{Int, Int}[], γ_type[], Int[], Int[], ScalarDictCPU())
+        blockR_tensor_dict = empty_engine_tensor_dict(engine)
+        trmatR = empty_engine_matrix_vector(engine)
+    else
+        blockR = blockL
+        blockR_tensor_dict = blockL_tensor_dict
+        trmatR = empty_engine_matrix_vector(engine)
+    end
+
+    return storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR
 end
 
 function _warmup_phase!(state::_FiniteState, config::_FiniteRunConfig, runtime::_FiniteRuntime)

--- a/src/finite_sweep.jl
+++ b/src/finite_sweep.jl
@@ -81,7 +81,7 @@ function _sweep_step!(SiSj, state::_SweepState, EE, storage, L, m, measurement, 
         root_println(runtime, graphic(state.sys_block, state.env_block; sys_label = state.sys_label))
     end
 
-    cor = measurement && (state.sys_label == :r || state.sys_block.length == 0) ? correlation : :none
+    cor = measurement && (state.sys_label == :r || state.sys_block.length == 0) ? correlation : Val(:none)
     result = dmrg_step_result!(SiSj, state.sys_label, state.sys_block, state.env_block, state.sys_tensor_dict, state.env_tensor_dict, state.sys_block_enl, state.env_block_enl, Ly, m..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); Ψ0_guess = Ψ0_guess, ES_max = ES_max, correlation = cor, margin = margin, lattice = lattice, Sj = state.Sj, alg = alg, noisy = verbose)
     state.sys_block = result.block
     state.sys_tensor_dict = result.tensor_dict

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -104,6 +104,13 @@ Lanczos!(A!, initial, position, comm, rank, engine; maxiter = 100, alg = :slow)
 returns eigenpairs of a linear map A!
 """
 function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter = 100, alg = :slow)
+    Lanczos!(A!, initial, position, comm, rank, engine, _alg_value(alg); maxiter = maxiter)
+end
+
+_alg_value(alg::Symbol) = Val(alg)
+_alg_value(alg::Val) = alg
+
+function Lanczos!(A!::Function, initial, position, comm, rank, engine, mode::Val; maxiter = 100)
     ketkm1 = deepcopy(initial)
     for I in eachindex(ketkm1)
         for J in eachindex(ketkm1[I])
@@ -119,10 +126,7 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
     vals = Float64[]
     vecs = zeros(0, 0)
     vold = Inf
-    if alg == :fast
-        m, n = size(ketk)
-        ketk_list = Matrix{Vector{Matrix{Float64}}}[]
-    end
+    cache = _init_lanczos_cache(mode, ketk)
     k = 1
     while true
         A!(ketk1, ketk)
@@ -152,9 +156,7 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
         mycopyto!(ketkm1, ketk)
         mycopyto!(ketk, ketk1)
         push!(βlist, β)
-        if alg == :fast
-            push!(ketk_list, map(x -> Array.(x), ketk))
-        end
+        _cache_lanczos_vector!(mode, cache, ketk)
         k += 1
     end
     vecs = MPI.bcast(vecs, 0, comm)::Matrix{Float64}
@@ -169,23 +171,7 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
     position = min(position, size(vecs, 2))
     myrmul!(initial, vecs[1, position])
     for k in 1 : size(vecs, 1) - 1
-        if alg == :slow
-            A!(ketk1, ketk)
-            α = αlist[k]
-            myaxpy!(-β, ketkm1, ketk1)
-            myaxpy!(-α, ketk, ketk1)
-            β = βlist[k]
-            myrdiv!(ketk1, β)
-            mycopyto!(ketkm1, ketk)
-            mycopyto!(ketk, ketk1)
-            myaxpy!(vecs[k + 1, position], ketk, initial)
-        else
-            if engine <: GPUEngine
-                myaxpy!(vecs[k + 1, position], [CuArray.(ketk_list[k][i, j]) for i in 1 : m, j in 1 : n], initial)
-            else
-                myaxpy!(vecs[k + 1, position], ketk_list[k], initial)
-            end
-        end
+        β = _lanczos_reconstruct_step!(mode, A!, engine, vecs[k + 1, position], cache, initial, ketk, ketk1, ketkm1, αlist, βlist, k, β)
     end
     myrdiv!(initial, sqrt(MPI.Allreduce(mydot(initial, initial), MPI.SUM, comm)))
     A!(ketk, initial)
@@ -198,4 +184,44 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine; maxiter =
         rtnval = CG!(A!, val, initial, ketk, ketkm1, ketk1, comm, rank)
     end
     rtnval
+end
+
+_init_lanczos_cache(::Val{:slow}, ketk) = nothing
+
+function _init_lanczos_cache(::Val{:fast}, ketk)
+    m, n = size(ketk)
+    return (m = m, n = n, vectors = Matrix{Vector{Matrix{Float64}}}[])
+end
+
+_cache_lanczos_vector!(::Val{:slow}, cache, ketk) = nothing
+
+function _cache_lanczos_vector!(::Val{:fast}, cache, ketk)
+    push!(cache.vectors, map(x -> Array.(x), ketk))
+    return nothing
+end
+
+function _lanczos_reconstruct_step!(::Val{:slow}, A!, engine, coeff, cache, initial, ketk, ketk1, ketkm1, αlist, βlist, k, β)
+    A!(ketk1, ketk)
+    α = αlist[k]
+    myaxpy!(-β, ketkm1, ketk1)
+    myaxpy!(-α, ketk, ketk1)
+    β = βlist[k]
+    myrdiv!(ketk1, β)
+    mycopyto!(ketkm1, ketk)
+    mycopyto!(ketk, ketk1)
+    myaxpy!(coeff, ketk, initial)
+    return β
+end
+
+function _lanczos_reconstruct_step!(::Val{:fast}, A!, engine, coeff, cache, initial, ketk, ketk1, ketkm1, αlist, βlist, k, β)
+    _fast_lanczos_axpy!(engine, coeff, cache.vectors[k], initial, cache.m, cache.n)
+    return β
+end
+
+function _fast_lanczos_axpy!(::Type{<:CPUEngine}, coeff, ketk, initial, m, n)
+    myaxpy!(coeff, ketk, initial)
+end
+
+function _fast_lanczos_axpy!(::Type{<:GPUEngine}, coeff, ketk, initial, m, n)
+    myaxpy!(coeff, [CuArray.(ketk[i, j]) for i in 1 : m, j in 1 : n], initial)
 end

--- a/src/measurement.jl
+++ b/src/measurement.jl
@@ -1,4 +1,5 @@
-_connection_or_tensor(connS, block_enl, conn) = isnothing(connS) ? block_enl.tensor_dict[conn] : connS
+_connection_or_tensor(connS::Nothing, block_enl, conn) = block_enl.tensor_dict[conn]
+_connection_or_tensor(connS, block_enl, conn) = connS
 _held_or_stored_tensor(tensor_dict_hold, tensor_dict, site) = haskey(tensor_dict_hold, site) ? tensor_dict_hold[site] : tensor_dict[site]
 
 function _enlarged_spin_tensor(ms, βs, dp, enlarging, source, engine)
@@ -90,12 +91,19 @@ tensor_dict, Sj = measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, 
 measurement phase
 """
 function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y_conn, sys_connS, env_connS, sys_len, env_len, sys_tensor_dict, env_tensor_dict, sys_tensor_dict_hold, env_tensor_dict_hold, sys_αs, env_αs, sys_βs, env_βs, sys_dp, env_dp, sys_ms, env_ms, sys_enlarge, env_enlarge, superblock_H2, OM, Ψ0, transformation_matrix, comm, rank, Ncpu, engine; correlation = :none, margin = 0, lattice = :square, Sj = Matrix{Vector{Matrix{Float64}}}(undef, 0, 0))
+    _measurement!(_val_mode(correlation), SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y_conn, sys_connS, env_connS, sys_len, env_len, sys_tensor_dict, env_tensor_dict, sys_tensor_dict_hold, env_tensor_dict_hold, sys_αs, env_αs, sys_βs, env_βs, sys_dp, env_dp, sys_ms, env_ms, sys_enlarge, env_enlarge, superblock_H2, OM, Ψ0, transformation_matrix, comm, rank, Ncpu, engine; margin = margin, lattice = lattice, Sj = Sj)
+end
+
+_val_mode(x::Val) = x
+_val_mode(x) = Val(x)
+
+function _measurement!(::Val{correlation}, SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y_conn, sys_connS, env_connS, sys_len, env_len, sys_tensor_dict, env_tensor_dict, sys_tensor_dict_hold, env_tensor_dict_hold, sys_αs, env_αs, sys_βs, env_βs, sys_dp, env_dp, sys_ms, env_ms, sys_enlarge, env_enlarge, superblock_H2, OM, Ψ0, transformation_matrix, comm, rank, Ncpu, engine; margin = 0, lattice = :square, Sj = Matrix{Vector{Matrix{Float64}}}(undef, 0, 0)) where correlation
     tensor_dict = empty_engine_tensor_dict(engine)
     sys_S = nothing
     env_S = nothing
 
     for x in 1 : min(sys_enl.length, Ly)
-        if isroot(rank) && (lattice != :honeycombZC || x == x_conn || ((mod1(sys.length, 2Ly) <= Ly) ? x == 1 : x == Ly) || (x <= x_conn ? iseven(x) : isodd(x)))
+        if isroot(rank) && (!_is_honeycomb_zc(lattice) || x == x_conn || ((mod1(sys.length, 2Ly) <= Ly) ? x == 1 : x == Ly) || (x <= x_conn ? iseven(x) : isodd(x)))
             if x == x_conn
                 Stemp = _connection_or_tensor(sys_connS, sys_enl, x_conn)
             else
@@ -105,7 +113,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
             tensor_dict[x] = _project_spin_tensor(Stemp, transformation_matrix, sys_len, engine)
         end
 
-        if correlation == :nn
+        if _measure_nn_correlation(Val(correlation))
             if x == x_conn
                 if isroot(rank)
                     sys_S = Stemp
@@ -123,7 +131,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
 
                 _store_sisj_bond!(SiSj, bond, sys_S, env_S, superblock_H2, OM, Ψ0, sys_len, env_len, sys_ms, env_ms, comm, rank, Ncpu, engine)
 
-            elseif env_enl.length % Ly == 0 && (lattice != :honeycombZC || (x_conn == 1 ? isodd(x) : iseven(x)))
+            elseif env_enl.length % Ly == 0 && (!_is_honeycomb_zc(lattice) || (x_conn == 1 ? isodd(x) : iseven(x)))
                 if isroot(rank)
                     sys_S = Stemp
                 end
@@ -162,13 +170,13 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
         end
     end
 
-    if correlation == :chain
+    if _measure_chain_correlation(Val(correlation))
         if isroot(rank)
             if !isempty(Sj) && (sys_label == :l && sys.length == 0)
-                Sj2 = engine <: GPUEngine ? [to_engine_array.(Ref(engine), Sj[i, j]) for i in 1 : length(env_αs), j in 1 : length(env_αs)] : Sj
+                Sj2 = engine_tensor_from_host(engine, Sj, length(env_αs))
                 env_S = _enlarged_spin_tensor(env_ms, env_βs, env_dp, env_enlarge, Sj2, engine)
             elseif !isempty(Sj)
-                Sj2 = engine <: GPUEngine ? [to_engine_array.(Ref(engine), Sj[i, j]) for i in 1 : length(sys_αs), j in 1 : length(sys_αs)] : Sj
+                Sj2 = engine_tensor_from_host(engine, Sj, length(sys_αs))
                 sys_S = _enlarged_spin_tensor(sys_ms, sys_βs, sys_dp, sys_enlarge, Sj2, engine)
             elseif x_conn == 1 && sys.length ÷ Ly == margin
                 sys_S = _connection_or_tensor(sys_connS, sys_enl, x_conn)
@@ -183,7 +191,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                 if isroot(rank)
                     sys_S = _connection_or_tensor(sys_connS, sys_enl, x_conn)
                 end
-            elseif y_conn == 1 || (lattice == :honeycombZC && y_conn <= 2)
+            elseif y_conn == 1 || (_is_honeycomb_zc(lattice) && y_conn <= 2)
                 N = sys_enl.length + env_enl.length
                 bond = (env_enl.length, iseven(margin) ? N - margin * Ly : N - (margin + 1) * Ly + 1)
 
@@ -192,7 +200,7 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
                 end
             end
 
-            if (sys_label == :l && sys.length == 0) || y_conn == 1 || (lattice == :honeycombZC && y_conn <= 2)
+            if (sys_label == :l && sys.length == 0) || y_conn == 1 || (_is_honeycomb_zc(lattice) && y_conn <= 2)
                 _store_sisj_bond!(SiSj, bond, sys_S, env_S, superblock_H2, OM, Ψ0, sys_len, env_len, sys_ms, env_ms, comm, rank, Ncpu, engine)
             end
 
@@ -206,3 +214,8 @@ function measurement!(SiSj, sys_label, sys, env, sys_enl, env_enl, Ly, x_conn, y
 
     tensor_dict, Sj
 end
+
+_measure_nn_correlation(::Val{:nn}) = true
+_measure_nn_correlation(mode) = false
+_measure_chain_correlation(::Val{:chain}) = true
+_measure_chain_correlation(mode) = false

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -3,12 +3,20 @@ struct _FiniteRuntime
     comm
     rank::Int
     Ncpu::Int
-    on_the_fly::Bool
+    on_the_fly
     mirror::Bool
     γ_type
     γ_list
     signfactor::Float64
 end
+
+_mode_value(x::Val{X}) where X = X
+_mode_value(x) = x
+_lattice_name(lattice) = _mode_value(lattice)
+_correlation_name(correlation) = _mode_value(correlation)
+_on_the_fly(on_the_fly) = _mode_value(on_the_fly)
+_is_honeycomb_zc(lattice) = _lattice_name(lattice) == :honeycombZC
+_is_square_lattice(lattice) = _lattice_name(lattice) == :square
 
 function init_DMRG!()
     if MPI.Finalized()
@@ -72,22 +80,32 @@ function _init_runtime_and_engine(engine, lattice, Lx, Ly, Nc, rank, Ncpu)
         push!(γ_list, SUNIrrep{Nc}(ntuple(i -> 0 + (i <= h), Val(Nc))))
     end
 
-    if engine <: GPUEngine
-        Ngpu = Int(length(devices()))
-        Ncpu <= Ngpu || throw(ArgumentError("Ncpu must be less than or equal to the number of GPUs"))
-        device!(rank)
-        magma_init()
-    end
+    _init_engine_runtime!(engine, rank, Ncpu)
 
     N = Lx * Ly
     signfactor = iseven(Nc) ? -1.0 : 1.0
-    return on_the_fly, mirror, γ_type, γ_list, N, signfactor
+    return Val(on_the_fly), mirror, γ_type, γ_list, N, signfactor
+end
+
+_init_engine_runtime!(::Type{<:CPUEngine}, rank, Ncpu) = nothing
+
+function _init_engine_runtime!(::Type{<:GPUEngine}, rank, Ncpu)
+    Ngpu = Int(length(devices()))
+    Ncpu <= Ngpu || throw(ArgumentError("Ncpu must be less than or equal to the number of GPUs"))
+    device!(rank)
+    magma_init()
+    return nothing
+end
+
+_finalize_engine_runtime!(::Type{<:CPUEngine}) = nothing
+
+function _finalize_engine_runtime!(::Type{<:GPUEngine})
+    magma_finalize()
+    return nothing
 end
 
 function _finalize_runtime!(engine, ::Nothing, rank)
-    if engine <: GPUEngine
-        magma_finalize()
-    end
+    _finalize_engine_runtime!(engine)
 end
 
 function _finalize_runtime!(engine, storage, rank)
@@ -95,7 +113,5 @@ function _finalize_runtime!(engine, storage, rank)
         cleanup_storage!(storage)
     end
 
-    if engine <: GPUEngine
-        magma_finalize()
-    end
+    _finalize_engine_runtime!(engine)
 end

--- a/src/step.jl
+++ b/src/step.jl
@@ -79,7 +79,8 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
     end
 
     _report_overlap(Ψ0_guess, Ψ0, comm, rank, noisy)
-    return DMRGStepResult(
+    return _dmrg_step_result(
+        Val(env_calc),
         newblock[1],
         newtensor_dict[1],
         newblock_enl[1],
@@ -89,15 +90,17 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
         trmat[1],
         ee[1],
         es[1],
-        env_calc ? nothing : Sj,
-        env_calc ? newblock[2] : nothing,
-        env_calc ? newtensor_dict[2] : nothing,
-        env_calc ? newblock_enl[2] : nothing,
-        env_calc ? trmat[2] : nothing,
+        Sj,
+        newblock,
+        newtensor_dict,
+        newblock_enl,
+        trmat,
     )
 end
 
-struct DMRGStepResult{B,T,BEnl,ΨT,TrT,EST,SJT,EB,ET,EBEnl,ETrT}
+abstract type AbstractDMRGStepResult end
+
+struct DMRGStepResult{B,T,BEnl,ΨT,TrT,EST,SJT} <: AbstractDMRGStepResult
     block::B
     tensor_dict::T
     block_enl::BEnl
@@ -108,10 +111,30 @@ struct DMRGStepResult{B,T,BEnl,ΨT,TrT,EST,SJT,EB,ET,EBEnl,ETrT}
     ee::Float64
     es::EST
     Sj::SJT
+end
+
+struct DMRGStepResultWithEnv{B,T,BEnl,ΨT,TrT,EST,EB,ET,EBEnl,ETrT} <: AbstractDMRGStepResult
+    block::B
+    tensor_dict::T
+    block_enl::BEnl
+    trerr::Float64
+    energy::Float64
+    Ψ::ΨT
+    trmat::TrT
+    ee::Float64
+    es::EST
     env_block::EB
     env_tensor_dict::ET
     env_block_enl::EBEnl
     env_trmat::ETrT
+end
+
+function _dmrg_step_result(::Val{false}, block, tensor_dict, block_enl, trerr, energy, Ψ, trmat, ee, es, Sj, newblock, newtensor_dict, newblock_enl, trmats)
+    DMRGStepResult(block, tensor_dict, block_enl, trerr, energy, Ψ, trmat, ee, es, Sj)
+end
+
+function _dmrg_step_result(::Val{true}, block, tensor_dict, block_enl, trerr, energy, Ψ, trmat, ee, es, Sj, newblock, newtensor_dict, newblock_enl, trmats)
+    DMRGStepResultWithEnv(block, tensor_dict, block_enl, trerr, energy, Ψ, trmat, ee, es, newblock[2], newtensor_dict[2], newblock_enl[2], trmats[2])
 end
 
 function dmrg_step_result!(args...; kwargs...)

--- a/src/step_density.jl
+++ b/src/step_density.jl
@@ -189,9 +189,9 @@ function _apply_density_matrix_correction!(ρs, switch, side::_StepSideContext, 
     for x in unique(map(z -> z[switch], superblock_bonds))
         if x == conn
             if switch == 1
-                Stemp = isnothing(sys_connS) ? sys_enl.tensor_dict[x_conn] : sys_connS
+                Stemp = _connection_or_tensor(sys_connS, sys_enl, x_conn)
             else
-                Stemp = isnothing(env_connS) ? env_enl.tensor_dict[y_conn] : env_connS
+                Stemp = _connection_or_tensor(env_connS, env_enl, y_conn)
             end
         else
             if switch == 1
@@ -206,11 +206,7 @@ function _apply_density_matrix_correction!(ρs, switch, side::_StepSideContext, 
         for k in 1 : len, l in 1 : len
             if haskey(dp[k], βs[l])
                 for τ1 in 1 : length(Stemp[l, k])
-                    if engine <: GPUEngine && Stemp[l, k][τ1] isa CuMatrix{Float64}
-                        Sρs[l] .+= UpperTriangular(Stemp[l, k][τ1] * CUBLAS.symm('R', 'U', ρs[k], Stemp[l, k][τ1])')
-                    else
-                        Sρs[l] .+= UpperTriangular(Stemp[l, k][τ1] * (Stemp[l, k][τ1] * Symmetric(ρs[k]))')
-                    end
+                    _add_density_correction!(Sρs[l], Stemp[l, k][τ1], ρs[k], engine)
                 end
             end
         end
@@ -221,4 +217,12 @@ function _apply_density_matrix_correction!(ρs, switch, side::_StepSideContext, 
     end
 
     return ρs
+end
+
+function _add_density_correction!(dest, spin, ρ, ::Type{<:CPUEngine})
+    dest .+= UpperTriangular(spin * (spin * Symmetric(ρ))')
+end
+
+function _add_density_correction!(dest, spin, ρ, ::Type{<:GPUEngine})
+    dest .+= UpperTriangular(spin * CUBLAS.symm('R', 'U', ρ, spin)')
 end

--- a/src/step_lanczos.jl
+++ b/src/step_lanczos.jl
@@ -20,9 +20,7 @@ function Lanczos_kernel!(Ψout, Ψin, x, y, sys_S, env_S, superblock_H2, OM, sys
         else
             temp3 = engine_matrix_type(engine)(undef, s.env_in_size, s.sys_in_size)
         end
-        if engine <: GPUEngine
-            CUDA.synchronize()
-        end
+        synchronize_engine(engine)
         MPI.Bcast!(temp3, root1, comm)
 
         if (x, y) != (0, 0)
@@ -36,9 +34,7 @@ function Lanczos_kernel!(Ψout, Ψin, x, y, sys_S, env_S, superblock_H2, OM, sys
     for ki in 1 : env_len, kj in 1 : sys_len
         for om in 1 : OM[kj, ki]
             root2 = (kj + ki - 2) % Ncpu
-            if engine <: GPUEngine
-                CUDA.synchronize()
-            end
+            synchronize_engine(engine)
             MPI.Reduce!(Ψtemp[ki, kj][om], MPI.SUM, root2, comm)
             if rank == root2
                 Ψout[ki, kj][om] .+= Ψtemp[ki, kj][om]
@@ -97,11 +93,9 @@ function _step_energy(E, time_Lanczos, sys_enl, env_enl, superblock_bonds, comm,
     return 0.0
 end
 
-function _report_overlap(Ψ0_guess, Ψ0, comm, rank, noisy)
-    if isnothing(Ψ0_guess)
-        return nothing
-    end
+_report_overlap(Ψ0_guess::Nothing, Ψ0, comm, rank, noisy) = nothing
 
+function _report_overlap(Ψ0_guess, Ψ0, comm, rank, noisy)
     nume = MPI.Reduce(mydot(Ψ0_guess, Ψ0), MPI.SUM, 0, comm)
     den1 = MPI.Reduce(mydot(Ψ0_guess, Ψ0_guess), MPI.SUM, 0, comm)
     den2 = MPI.Reduce(mydot(Ψ0, Ψ0), MPI.SUM, 0, comm)

--- a/src/step_types.jl
+++ b/src/step_types.jl
@@ -53,12 +53,12 @@ struct _StepSideContext{MS,B,D,BT,BET}
     block_enl::BET
 end
 
-struct _StepLanczosContext{CommT,E,H1,BondsT,SysConnT,EnvConnT,MST,BetaT,DPT,EnlargeT,SysTensorT,EnvTensorT,H2T,OMT}
+struct _StepLanczosContext{CommT,E,A,H1,BondsT,SysConnT,EnvConnT,MST,BetaT,DPT,EnlargeT,SysTensorT,EnvTensorT,H2T,OMT}
     target::Int
     comm::CommT
     rank::Int
     engine::Type{E}
-    alg::Symbol
+    alg::A
     superblock_H1::H1
     bonds_hold::BondsT
     x_conn::Int
@@ -93,7 +93,7 @@ struct _StepDensityContext{CommT,E}
     noisy::Bool
 end
 
-struct _StepMeasurementContext{SiSjT,SysConnT,EnvConnT,SysTensorT,EnvTensorT,SysTensorHoldT,EnvTensorHoldT,BetaT,DPT,MST,EnlargeT,H2T,OMT,CommT,E}
+struct _StepMeasurementContext{SiSjT,SysConnT,EnvConnT,SysTensorT,EnvTensorT,SysTensorHoldT,EnvTensorHoldT,BetaT,DPT,MST,EnlargeT,H2T,OMT,CommT,E,C,L}
     SiSj::SiSjT
     Ly::Int
     x_conn::Int
@@ -122,12 +122,12 @@ struct _StepMeasurementContext{SiSjT,SysConnT,EnvConnT,SysTensorT,EnvTensorT,Sys
     rank::Int
     Ncpu::Int
     engine::Type{E}
-    correlation::Symbol
+    correlation::C
     margin::Int
-    lattice::Symbol
+    lattice::L
 end
 
-struct _StepBlockContext{CommT,TablesT,E}
+struct _StepBlockContext{CommT,TablesT,O,E,L}
     Ly::Int
     widthmax::Int
     signfactor::Float64
@@ -135,9 +135,9 @@ struct _StepBlockContext{CommT,TablesT,E}
     rank::Int
     Ncpu::Int
     tables::TablesT
-    on_the_fly::Bool
+    on_the_fly::O
     engine::Type{E}
-    lattice::Symbol
+    lattice::L
 end
 
 struct _StepCorrectionContext{BondsT,SysConnT,EnvConnT,SysEnlT,EnvEnlT,SysTensorHoldT,EnvTensorHoldT,SysTensorT,EnvTensorT,MST,DPT,BetaT,EnlargeT,E}

--- a/src/step_workspace.jl
+++ b/src/step_workspace.jl
@@ -6,7 +6,7 @@ function _build_block_enlarging(Nc, αs, βs, dp, αβmatrix, cum_mαβ, adjoint
         if haskey(dp[j], βs[i])
             for ki in findall(αβmatrix[:, i]), kj in findall(αβmatrix[:, j])
                 if haskey(dp2[kj], αs[ki])
-                    matrix = on_the_fly ? on_the_fly_calc1(Nc, (αs[kj], βs[j], αs[ki], βs[i])) : tables[1][αs[kj], βs[j], αs[ki], βs[i]]
+                    matrix = _on_the_fly(on_the_fly) ? on_the_fly_calc1(Nc, (αs[kj], βs[j], αs[ki], βs[i])) : tables[1][αs[kj], βs[j], αs[ki], βs[i]]
                     for τ1 in 1 : size(matrix, 2), τ2 in 1 : size(matrix, 1)
                         push!(enlarging, BlockEnlarging(matrix[τ2, τ1], τ1, τ2, cum_mαβ[ki, i] + 1 : cum_mαβ[ki + 1, i], cum_mαβ[kj, j] + 1 : cum_mαβ[kj + 1, j], i, j, ki, kj))
                     end
@@ -22,6 +22,10 @@ function _empty_tensor_hold(engine)
 end
 
 function _broadcast_tensor_holds(tensor_dict, mβ_list, conn, held_sites, comm, rank, engine; to_engine = false)
+    _broadcast_tensor_holds(tensor_dict, mβ_list, conn, held_sites, comm, rank, engine, Val(to_engine))
+end
+
+function _broadcast_tensor_holds(tensor_dict, mβ_list, conn, held_sites, comm, rank, engine, ::Val{to_engine}) where to_engine
     tensor_dict_hold = _empty_tensor_hold(engine)
 
     if rank == 0
@@ -52,11 +56,7 @@ function _broadcast_tensor_holds(tensor_dict, mβ_list, conn, held_sites, comm, 
             end
 
             if site ∈ held_sites
-                if to_engine
-                    tensor_dict_hold[site] = [to_engine_array.(Ref(engine), Sold[i, j]) for i in 1 : len, j in 1 : len]
-                else
-                    tensor_dict_hold[site] = Sold
-                end
+                tensor_dict_hold[site] = _tensor_hold_value(engine, Sold, len, Val(to_engine))
             end
         end
     end
@@ -64,15 +64,18 @@ function _broadcast_tensor_holds(tensor_dict, mβ_list, conn, held_sites, comm, 
     tensor_dict_hold
 end
 
+_tensor_hold_value(engine, tensor, len, ::Val{false}) = tensor
+_tensor_hold_value(engine, tensor, len, ::Val{true}) = [to_engine_array.(Ref(engine), tensor[i, j]) for i in 1 : len, j in 1 : len]
+
 function _step_bonds(sys_length, env_length, Ly, lattice)
     superblock_bonds = [(y, y) for y in 1 : min(sys_length, env_length, Ly)]
     x_conn = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(sys_length, 2Ly))
     y_conn = (x -> x <= Ly ? x : 2Ly + 1 - x)(mod1(env_length, 2Ly))
 
-    if lattice == :honeycombZC
+    if _is_honeycomb_zc(lattice)
         filter!(z -> z[1] <= min(x_conn, y_conn) ? iseven(z[1]) : isodd(z[1]), superblock_bonds)
     end
-    if (x_conn, y_conn) ∉ superblock_bonds && !(lattice == :honeycombZC && sys_length <= Ly && env_length <= Ly)
+    if (x_conn, y_conn) ∉ superblock_bonds && !(_is_honeycomb_zc(lattice) && sys_length <= Ly && env_length <= Ly)
         push!(superblock_bonds, (x_conn, y_conn))
     end
 
@@ -99,24 +102,21 @@ function _rank_held_bonds(superblock_bonds, Ncpu, rank)
 end
 
 function _build_superblock_h1(sys_enl, env_enl, OM, Ncpu, rank, engine)
-    if engine <: GPUEngine
-        superblock_H1 = SuperBlock1GPU[]
-    else
-        superblock_H1 = SuperBlock1CPU[]
-    end
+    superblock_H1 = _empty_superblock_h1(engine)
 
     for k1 in axes(OM, 1), k2 in axes(OM, 2)
         if OM[k1, k2] > 0 && (k1 + k2 - 2) % Ncpu == rank
-            if engine <: GPUEngine
-                push!(superblock_H1, SuperBlock1GPU(sys_enl.scalar_dict[:H][k1], env_enl.scalar_dict[:H][k2], k1, k2))
-            else
-                push!(superblock_H1, SuperBlock1CPU(sys_enl.scalar_dict[:H][k1], env_enl.scalar_dict[:H][k2], k1, k2))
-            end
+            _push_superblock_h1!(superblock_H1, engine, sys_enl.scalar_dict[:H][k1], env_enl.scalar_dict[:H][k2], k1, k2)
         end
     end
 
     return superblock_H1
 end
+
+_empty_superblock_h1(::Type{<:CPUEngine}) = SuperBlock1CPU[]
+_empty_superblock_h1(::Type{<:GPUEngine}) = SuperBlock1GPU[]
+_push_superblock_h1!(superblock_H1, ::Type{<:CPUEngine}, sys_H, env_H, k1, k2) = push!(superblock_H1, SuperBlock1CPU(sys_H, env_H, k1, k2))
+_push_superblock_h1!(superblock_H1, ::Type{<:GPUEngine}, sys_H, env_H, k1, k2) = push!(superblock_H1, SuperBlock1GPU(sys_H, env_H, k1, k2))
 
 function _build_superblock_h2(Nc, sys_βs, env_βs, sys_ms, env_ms, sys_dp, env_dp, OM, γirrep, signfactor, tables, on_the_fly)
     fac = sqrt(Nc ^ 2 - 1) * signfactor
@@ -129,7 +129,7 @@ function _build_superblock_h2(Nc, sys_βs, env_βs, sys_ms, env_ms, sys_dp, env_
                 if haskey(sys_dp[k1], sys_βs[k3])
                     for k4 in eachindex(env_βs)
                         if haskey(env_dp[k2], env_βs[k4]) && OM[k3, k4] > 0
-                            ctensor = on_the_fly ? on_the_fly_calc4(Nc, (sys_βs[k1], env_βs[k2], γirrep, sys_βs[k3], env_βs[k4])) : tables[4][sys_βs[k1], env_βs[k2], γirrep, sys_βs[k3], env_βs[k4]]
+                            ctensor = _on_the_fly(on_the_fly) ? on_the_fly_calc4(Nc, (sys_βs[k1], env_βs[k2], γirrep, sys_βs[k3], env_βs[k4])) : tables[4][sys_βs[k1], env_βs[k2], γirrep, sys_βs[k3], env_βs[k4]]
                             for τ1 in 1 : size(ctensor, 1), τ2 in 1 : size(ctensor, 2), om2 in 1 : size(ctensor, 3)
                                 push!(miniblock, MiniBlock(fac * ctensor[τ1, τ2, om2, om1], om2, τ1, τ2, k3, k4))
                             end
@@ -187,37 +187,39 @@ function _prepare_step_workspace(sys, env, sys_tensor_dict, env_tensor_dict, sys
 
     sys_connS = _connection_tensor(sys_enl, x_conn, held_x)
     env_connS = _connection_tensor(env_enl, y_conn, held_y)
-    sys_tensor_dict_hold = _broadcast_tensor_holds(sys_tensor_dict, sys.mβ_list, x_conn, held_x, comm, rank, engine; to_engine = engine <: GPUEngine)
+    sys_tensor_dict_hold = _broadcast_tensor_holds(sys_tensor_dict, sys.mβ_list, x_conn, held_x, comm, rank, engine, _tensor_hold_to_engine(engine))
     env_tensor_dict_hold = _broadcast_tensor_holds(env_tensor_dict, env.mβ_list, y_conn, held_y, comm, rank, engine)
 
     return _StepWorkspace(sys_αs, env_αs, sys_βs, env_βs, sys_ms, env_ms, sys_len, env_len, superblock_bonds, bonds_hold, x_conn, y_conn, sys_dp, env_dp, sys_enlarge, env_enlarge, OM, superblock_H1, superblock_H2, sys_connS, env_connS, sys_tensor_dict_hold, env_tensor_dict_hold)
 end
 
-function _initial_step_wavefunction(Ψ0_guess, env_ms, sys_ms, OM, Ncpu, rank, engine)
-    if !isnothing(Ψ0_guess)
-        return deepcopy(Ψ0_guess)
-    end
+_tensor_hold_to_engine(::Type{<:CPUEngine}) = Val(false)
+_tensor_hold_to_engine(::Type{<:GPUEngine}) = Val(true)
 
-    if engine <: GPUEngine
-        return [[CUDA.rand(Float64, env_ms[ki], sys_ms[kj]) for J in 1 : ((kj + ki - 2) % Ncpu == rank ? OM[kj, ki] : 0)] for ki in eachindex(env_ms), kj in eachindex(sys_ms)]
-    end
-
-    return [[rand(env_ms[ki], sys_ms[kj]) for J in 1 : ((kj + ki - 2) % Ncpu == rank ? OM[kj, ki] : 0)] for ki in eachindex(env_ms), kj in eachindex(sys_ms)]
+function _initial_step_wavefunction(Ψ0_guess::Nothing, env_ms, sys_ms, OM, Ncpu, rank, engine)
+    [[_random_engine_matrix(engine, env_ms[ki], sys_ms[kj]) for J in 1 : ((kj + ki - 2) % Ncpu == rank ? OM[kj, ki] : 0)] for ki in eachindex(env_ms), kj in eachindex(sys_ms)]
 end
+
+function _initial_step_wavefunction(Ψ0_guess, env_ms, sys_ms, OM, Ncpu, rank, engine)
+    deepcopy(Ψ0_guess)
+end
+
+_random_engine_matrix(::Type{<:CPUEngine}, rows, cols) = rand(rows, cols)
+_random_engine_matrix(::Type{<:GPUEngine}, rows, cols) = CUDA.rand(Float64, rows, cols)
 
 function _step_result_buffers(::Val{Nc}, engine) where Nc
     newblock = Block{Nc}[]
-    if engine <: GPUEngine
-        newblock_enl = EnlargedBlockGPU{Nc}[]
-        trmat = Vector{CuMatrix{Float64}}[]
-        newtensor_dict = Dict{Int64, Matrix{Vector{CuMatrix{Float64}}}}[]
-    else
-        newblock_enl = EnlargedBlockCPU{Nc}[]
-        trmat = Vector{Matrix{Float64}}[]
-        newtensor_dict = Dict{Int64, Matrix{Vector{Matrix{Float64}}}}[]
-    end
+    newblock_enl, trmat, newtensor_dict = _step_engine_result_buffers(Val(Nc), engine)
 
     return newblock, newblock_enl, trmat, newtensor_dict
+end
+
+function _step_engine_result_buffers(::Val{Nc}, ::Type{<:CPUEngine}) where Nc
+    EnlargedBlockCPU{Nc}[], Vector{Matrix{Float64}}[], Dict{Int64, Matrix{Vector{Matrix{Float64}}}}[]
+end
+
+function _step_engine_result_buffers(::Val{Nc}, ::Type{<:GPUEngine}) where Nc
+    EnlargedBlockGPU{Nc}[], Vector{CuMatrix{Float64}}[], Dict{Int64, Matrix{Vector{CuMatrix{Float64}}}}[]
 end
 
 function _step_side_context(switch, sys_label, sys_len, env_len, sys_ms, env_ms, sys_βs, env_βs, sys_dp, env_dp, x_conn, y_conn, sys, env, sys_enl, env_enl)

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -1,5 +1,8 @@
 abstract type AbstractInternalStorage end
 
+const _HostTrmat = Vector{Matrix{Float64}}
+const _HostTensor = Matrix{Vector{Matrix{Float64}}}
+
 struct MemoryInternalStorage{B, T, TT} <: AbstractInternalStorage
     block_table::B
     trmat_table::T
@@ -8,19 +11,23 @@ end
 
 struct JLD2InternalStorage <: AbstractInternalStorage
     scratch::String
-    dirid
+    dirid::String
 end
 
 _storage_dir(storage::JLD2InternalStorage) = joinpath(storage.scratch, "temp$(storage.dirid)")
 
-function init_internal_storage(fileio, scratch, block_table, trmat_table, tensor_table, rank)
-    if fileio
-        dirid = rank == 0 ? lpad(rand(0 : 99999), 5, "0") : 0
-        if rank == 0
-            mkdir(joinpath(scratch, "temp$dirid"))
-        end
-        return JLD2InternalStorage(scratch, dirid)
+init_internal_storage(fileio::Bool, scratch, block_table, trmat_table, tensor_table, rank) =
+    init_internal_storage(Val(fileio), scratch, block_table, trmat_table, tensor_table, rank)
+
+function init_internal_storage(::Val{true}, scratch, block_table, trmat_table, tensor_table, rank)
+    dirid = rank == 0 ? lpad(rand(0 : 99999), 5, "0") : "00000"
+    if rank == 0
+        mkdir(joinpath(scratch, "temp$dirid"))
     end
+    return JLD2InternalStorage(scratch, dirid)
+end
+
+function init_internal_storage(::Val{false}, scratch, block_table, trmat_table, tensor_table, rank)
     return MemoryInternalStorage(block_table, trmat_table, tensor_table)
 end
 
@@ -48,6 +55,12 @@ function load_tensor(storage::MemoryInternalStorage, label, len, y)
     pop!(storage.tensor_table, (label, len, y), nothing)
 end
 
+has_tensor(storage::MemoryInternalStorage, label, len, y) = haskey(storage.tensor_table, (label, len, y))
+
+function take_tensor!(storage::MemoryInternalStorage, label, len, y)
+    pop!(storage.tensor_table, (label, len, y))::_HostTensor
+end
+
 function save_tensor(storage::MemoryInternalStorage, label, len, y, tensor)
     storage.tensor_table[label, len, y] = tensor
 end
@@ -61,7 +74,7 @@ function save_block(storage::JLD2InternalStorage, label, len, block)
 end
 
 function load_trmat(storage::JLD2InternalStorage, label, len)
-    load_object(_trmat_filename(storage, label, len))::Vector{Matrix{Float64}}
+    load_object(_trmat_filename(storage, label, len))::_HostTrmat
 end
 
 function save_trmat(storage::JLD2InternalStorage, label, len, trmat)
@@ -87,12 +100,21 @@ end
 function load_tensor(storage::JLD2InternalStorage, label, len, y)
     filename = _tensor_filename(storage, label, len, y)
     if isfile(filename)
-        tensor = load_object(filename)::Matrix{Vector{Matrix{Float64}}}
+        tensor = load_object(filename)::_HostTensor
         rm(filename)
         tensor
     else
         nothing
     end
+end
+
+has_tensor(storage::JLD2InternalStorage, label, len, y) = isfile(_tensor_filename(storage, label, len, y))
+
+function take_tensor!(storage::JLD2InternalStorage, label, len, y)
+    filename = _tensor_filename(storage, label, len, y)
+    tensor = load_object(filename)::_HostTensor
+    rm(filename)
+    return tensor
 end
 
 function save_tensor(storage::JLD2InternalStorage, label, len, y, tensor)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -63,7 +63,7 @@ function eig_prediction(Ψ0, sys_label, sys_enl::EnlargedBlock{Nc}, env_enl::Enl
                     βl = sys_βs[l]
                     if (i + l - 2) % Ncpu == rank && sys_mαβ[j, l] > 0
                         temp3 = env_trmat[i] * temp2[cum_env_mαβ[i, k] + 1 : cum_env_mαβ[i + 1, k], :]
-                        cmatrix = on_the_fly ? on_the_fly_calc5(Nc, (αj, βl, αi, γirrep, βk)) : tables[5][αj, βl, αi, γirrep, βk]
+                        cmatrix = _on_the_fly(on_the_fly) ? on_the_fly_calc5(Nc, (αj, βl, αi, γirrep, βk)) : tables[5][αj, βl, αi, γirrep, βk]
                         for om1 in 1 : OM[l, i]
                             @. Ψ0_guess[i, l][om1][:, cum_sys_mαβ[j, l] + 1 : cum_sys_mαβ[j + 1, l]] += cmatrix[om2, om1] * temp3
                         end
@@ -103,7 +103,7 @@ function _wavefunction_reverse(Ψ0, sys_label, sys, env, widthmax, comm, rank, N
     for j in 1 : size(Ψ0, 2), i in 1 : size(Ψ0, 1)
         OM = length(Ψ0[i, j])
         if OM > 0
-            rmatrix = (on_the_fly ? on_the_fly_calc6((sys_βs[j], env_βs[i], γirrep)) : tables[6][sys_βs[j], env_βs[i], γirrep])
+            rmatrix = (_on_the_fly(on_the_fly) ? on_the_fly_calc6((sys_βs[j], env_βs[i], γirrep)) : tables[6][sys_βs[j], env_βs[i], γirrep])
             for τ in 1 : OM, τ′ in 1 : OM
                 @. Ψ0_new[j, i][τ′] += rmatrix[τ′, τ] * Ψ0[i, j][τ]'
             end

--- a/test/test_finite_helpers.jl
+++ b/test/test_finite_helpers.jl
@@ -68,19 +68,16 @@
 end
 
 @testset "DMRG step result" begin
-    step = SUNDMRG.DMRGStepResult(1, 2, 3, 4.0, 5.0, 6, 7, 8.0, 9, 10, nothing, nothing, nothing, nothing)
+    step = SUNDMRG.DMRGStepResult(1, 2, 3, 4.0, 5.0, 6, 7, 8.0, 9, 10)
     @test step.block == 1
     @test step.es == 9
     @test step.Sj == 10
-    @test step.env_block === nothing
-    @test step.env_tensor_dict === nothing
-    @test step.env_block_enl === nothing
-    @test step.env_trmat === nothing
+    @test step isa SUNDMRG.DMRGStepResult
 
-    env_step = SUNDMRG.DMRGStepResult(1, 2, 3, 4.0, 5.0, 6, 7, 8.0, 9, nothing, 10, 11, 12, 13)
+    env_step = SUNDMRG.DMRGStepResultWithEnv(1, 2, 3, 4.0, 5.0, 6, 7, 8.0, 9, 10, 11, 12, 13)
     @test env_step.block == 1
     @test env_step.es == 9
-    @test env_step.Sj === nothing
+    @test env_step isa SUNDMRG.DMRGStepResultWithEnv
     @test env_step.env_block == 10
     @test env_step.env_tensor_dict == 11
     @test env_step.env_block_enl == 12


### PR DESCRIPTION
## Summary

- Bump the package version to v1.4.6.
- Refactor CPU/GPU engine helpers, storage initialization, runtime modes, Lanczos modes, and DMRG step results to improve type inference.
- Move several `Bool`, `Symbol`, and `Nothing`-sentinel paths toward dispatch or typed helper boundaries.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `SUNDMRG CPU-only pure tests | 226 passed`
- Spot-checked selected helpers with `@code_warntype` for concrete inferred return types.