### PR TITLE
[codex] Prepare v1.4.7 review fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.4.6"
+version = "1.4.7"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/examples/sample_su3_cpu.jl
+++ b/examples/sample_su3_cpu.jl
@@ -4,7 +4,7 @@ using JLD2
 function main()
     Nc = 3
     widthmax = 13
-    @load "../jld2/table_SU$(Nc)_$widthmax.jld2" tables
+    @load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
     Lx = parse(Int, ARGS[1])
     Ly = parse(Int, ARGS[2])
     correlation = Lx < 30 ? :nn : :chain

--- a/examples/sample_su3_gpu.jl
+++ b/examples/sample_su3_gpu.jl
@@ -4,7 +4,7 @@ using JLD2
 function main()
     Nc = 3
     widthmax = 13
-    @load "../jld2/table_SU$(Nc)_$widthmax.jld2" tables
+    @load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
     Lx = parse(Int, ARGS[1])
     Ly = parse(Int, ARGS[2])
     correlation = Lx < 30 ? :nn : :chain

--- a/examples/sample_su4_cpu.jl
+++ b/examples/sample_su4_cpu.jl
@@ -4,7 +4,7 @@ using JLD2
 function main()
     Nc = 4
     widthmax = 9
-    @load "../jld2/table_SU$(Nc)_$widthmax.jld2" tables
+    @load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
     Lx = parse(Int, ARGS[1])
     Ly = parse(Int, ARGS[2])
     correlation = Lx < 30 ? :nn : :chain

--- a/examples/sample_su4_gpu.jl
+++ b/examples/sample_su4_gpu.jl
@@ -4,7 +4,7 @@ using JLD2
 function main()
     Nc = 4
     widthmax = 9
-    @load "../jld2/table_SU$(Nc)_$widthmax.jld2" tables
+    @load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
     Lx = parse(Int, ARGS[1])
     Ly = parse(Int, ARGS[2])
     correlation = Lx < 30 ? :nn : :chain

--- a/examples/sample_su5_cpu.jl
+++ b/examples/sample_su5_cpu.jl
@@ -4,7 +4,7 @@ using JLD2
 function main()
     Nc = 5
     widthmax = 3
-    @load "../jld2/table_SU$(Nc)_$widthmax.jld2" tables
+    @load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
     Lx = parse(Int, ARGS[1])
     Ly = parse(Int, ARGS[2])
     correlation = Lx < 30 ? :nn : :chain

--- a/examples/sample_su5_gpu.jl
+++ b/examples/sample_su5_gpu.jl
@@ -4,7 +4,7 @@ using JLD2
 function main()
     Nc = 5
     widthmax = 3
-    @load "../jld2/table_SU$(Nc)_$widthmax.jld2" tables
+    @load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
     Lx = parse(Int, ARGS[1])
     Ly = parse(Int, ARGS[2])
     correlation = Lx < 30 ? :nn : :chain

--- a/src/block.jl
+++ b/src/block.jl
@@ -1,3 +1,4 @@
+# Scalar dictionaries currently carry :H and leave room for additional scalar operators.
 const ScalarDictCPU = Dict{Symbol, Vector{Matrix{Float64}}}
 const TensorMatrixCPU = Matrix{Vector{Matrix{Float64}}}
 const TensorDictCPU = Dict{Int, TensorMatrixCPU}

--- a/src/finite_sweep.jl
+++ b/src/finite_sweep.jl
@@ -115,8 +115,7 @@ function _update_measurement_flag(measurement, energies, EEs, config::_FiniteRun
 
     if isroot(runtime)
         measurement = abs((energies[end] - energies[end - 1]) / energies[end]) < tol_energy && abs((EEs[end] - EEs[end - 1]) / EEs[end]) < tol_EE
-        MPI.bcast(measurement, 0, comm)
-        return measurement
+        return MPI.bcast(measurement, 0, comm)::Bool
     end
 
     MPI.bcast(nothing, 0, comm)::Bool

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -111,12 +111,7 @@ _alg_value(alg::Symbol) = Val(alg)
 _alg_value(alg::Val) = alg
 
 function Lanczos!(A!::Function, initial, position, comm, rank, engine, mode::Val; maxiter = 100)
-    ketkm1 = deepcopy(initial)
-    for I in eachindex(ketkm1)
-        for J in eachindex(ketkm1[I])
-            ketkm1[I][J] .= 0.0
-        end
-    end
+    ketkm1 = _zero_lanczos_vector(initial)
     myrdiv!(initial, sqrt(MPI.Allreduce(mydot(initial, initial), MPI.SUM, comm)))
     ketk = deepcopy(initial)
     ketk1 = deepcopy(ketk)
@@ -133,11 +128,8 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine, mode::Val
         α = MPI.Allreduce(mydot(ketk, ketk1), MPI.SUM, comm)
         push!(αlist, α)
         if k >= position
-            if rank == 0
-                vals, vecs = LAPACK.stev!('V', copy(αlist), copy(βlist))
-            end
-            vals = MPI.bcast(vals, 0, comm)::Vector{Float64}
-            if k == maxiter || abs((vals[position] - vold) / vals[position]) < tol_Lanczos
+            vals, vecs = _lanczos_ritz_vectors(αlist, βlist, comm, rank)
+            if k == maxiter || _lanczos_eigenvalue_converged(vals[position], vold)
                 break
             end
             vold = vals[position]
@@ -146,10 +138,7 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine, mode::Val
         myaxpy!(-α, ketk, ketk1)
         β = sqrt(MPI.Allreduce(mydot(ketk1, ketk1), MPI.SUM, comm))
         if β == 0.0
-            if rank == 0
-                vals, vecs = LAPACK.stev!('V', copy(αlist), copy(βlist))
-            end
-            vals = MPI.bcast(vals, 0, comm)::Vector{Float64}
+            vals, vecs = _lanczos_ritz_vectors(αlist, βlist, comm, rank)
             break
         end
         myrdiv!(ketk1, β)
@@ -160,7 +149,38 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine, mode::Val
         k += 1
     end
     vecs = MPI.bcast(vecs, 0, comm)::Matrix{Float64}
+    if size(vecs, 2) == 0
+        return first(αlist)
+    end
 
+    position = _reconstruct_lanczos_vector!(mode, A!, engine, initial, ketk, ketk1, ketkm1, vecs, αlist, βlist, position, cache)
+    _refine_lanczos_vector!(A!, initial, ketk, ketkm1, ketk1, vals[position], comm, rank)
+end
+
+function _zero_lanczos_vector(initial)
+    ket = deepcopy(initial)
+    for I in eachindex(ket)
+        for J in eachindex(ket[I])
+            ket[I][J] .= 0.0
+        end
+    end
+    return ket
+end
+
+function _lanczos_ritz_vectors(αlist, βlist, comm, rank)
+    vals = Float64[]
+    vecs = zeros(0, 0)
+    if rank == 0
+        vals, vecs = LAPACK.stev!('V', copy(αlist), copy(βlist))
+    end
+    vals = MPI.bcast(vals, 0, comm)::Vector{Float64}
+    return vals, vecs
+end
+
+_lanczos_eigenvalue_converged(val, vold) = abs(val - vold) < tol_Lanczos * max(abs(val), 1.0)
+_lanczos_wavefunction_converged(val, target_val, var) = abs(val - target_val) < tol_wavefunction * max(abs(val), 1.0) && abs(var - val ^ 2) < tol_wavefunction * max(abs(val ^ 2), 1.0)
+
+function _reconstruct_lanczos_vector!(mode::Val, A!, engine, initial, ketk, ketk1, ketkm1, vecs, αlist, βlist, position, cache)
     for I in eachindex(ketkm1)
         for J in eachindex(ketkm1[I])
             ketkm1[I][J] .= 0.0
@@ -173,17 +193,18 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine, mode::Val
     for k in 1 : size(vecs, 1) - 1
         β = _lanczos_reconstruct_step!(mode, A!, engine, vecs[k + 1, position], cache, initial, ketk, ketk1, ketkm1, αlist, βlist, k, β)
     end
+    return position
+end
+
+function _refine_lanczos_vector!(A!, initial, ketk, ketkm1, ketk1, target_val, comm, rank)
     myrdiv!(initial, sqrt(MPI.Allreduce(mydot(initial, initial), MPI.SUM, comm)))
     A!(ketk, initial)
     val = MPI.Allreduce(mydot(initial, ketk), MPI.SUM, comm)
-    val2 = val ^ 2
     var = MPI.Allreduce(mydot(ketk, ketk), MPI.SUM, comm)
-    if abs((val - vals[position]) / val) < tol_wavefunction && abs((var - val2) / val2) < tol_wavefunction
-        rtnval = val
-    else
-        rtnval = CG!(A!, val, initial, ketk, ketkm1, ketk1, comm, rank)
+    if _lanczos_wavefunction_converged(val, target_val, var)
+        return val
     end
-    rtnval
+    return CG!(A!, val, initial, ketk, ketkm1, ketk1, comm, rank)
 end
 
 _init_lanczos_cache(::Val{:slow}, ketk) = nothing

--- a/src/step.jl
+++ b/src/step.jl
@@ -27,7 +27,7 @@ function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_
         (; len, ms, dp, conn, label, block, block_enl) = side
         βs = side.betas
 
-        balancer = _density_matrix_balancer(ms, density_context.Ncpu, density_context.rank)
+        balancer::Vector{Int} = _density_matrix_balancer(ms, density_context.Ncpu, density_context.rank)
         MPI.Bcast!(balancer, 0, comm)
 
         dimβ = dim.(βs)

--- a/src/step_density.jl
+++ b/src/step_density.jl
@@ -1,25 +1,14 @@
-function _density_matrix_balancer(ms, Ncpu, rank)
+function _density_matrix_balancer(ms, Ncpu, rank)::Vector{Int}
     len = length(ms)
     balancer = zeros(Int, len)
     if rank == 0 && Ncpu > 1 && len > 0
         max_m = maximum(ms)
         loads = @. (ms / max_m) ^ 3
         load_sum = zeros(Float64, Ncpu)
-        load_sum[1] = sum(loads)
-        load_max = maximum(load_sum)
-        for i in 1 : 100
-            j = rand(1 : len)
-            new_b = rand(filter(x -> x != balancer[j], 0 : Ncpu - 1))
-            load_sum[balancer[j] + 1] -= loads[j]
-            load_sum[new_b + 1] += loads[j]
-            new_load_max = maximum(load_sum)
-            if log(rand()) < 100.0 * (load_max - new_load_max)
-                balancer[j] = new_b
-                load_max = new_load_max
-            else
-                load_sum[balancer[j] + 1] += loads[j]
-                load_sum[new_b + 1] -= loads[j]
-            end
+        for j in sortperm(loads; rev = true)
+            b = argmin(load_sum)
+            balancer[j] = b - 1
+            load_sum[b] += loads[j]
         end
     end
     return balancer

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -20,9 +20,10 @@ init_internal_storage(fileio::Bool, scratch, block_table, trmat_table, tensor_ta
     init_internal_storage(Val(fileio), scratch, block_table, trmat_table, tensor_table, rank)
 
 function init_internal_storage(::Val{true}, scratch, block_table, trmat_table, tensor_table, rank)
-    dirid = rank == 0 ? lpad(rand(0 : 99999), 5, "0") : "00000"
+    dirid = "00000"
     if rank == 0
-        mkdir(joinpath(scratch, "temp$dirid"))
+        dirname = basename(mktempdir(scratch; prefix = "temp"))
+        dirid = startswith(dirname, "temp") ? dirname[5:end] : dirname
     end
     return JLD2InternalStorage(scratch, dirid)
 end

--- a/src/suncalc.jl
+++ b/src/suncalc.jl
@@ -148,6 +148,7 @@ function wigner9ν(ν1::SUNIrrep{Nc}, ν2::SUNIrrep{Nc}, ν12::SUNIrrep{Nc}, ν3
             return reshape([sqrt((μ12 + 1) * (μ34 + 1) * (μ13 + 1) * (μ24 + 1)) * wigner9j(j1, j2, j12, j3, j4, j34, j13, j24, j)], 1, 1, 1, 1, 1, 1)
         end
     end
+    throw(ArgumentError("on-the-fly wigner9ν is implemented only for SU(2); use precomputed tables for SU(N > 2)"))
 end
 
 """

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -93,6 +93,7 @@ function wavefunction_reverse(Ψ0, sys_label, sys_block::Block{Nc}, env_block::B
 end
 
 function _wavefunction_reverse(Ψ0, sys_label, sys, env, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Nc)
+    # sys_label is kept for API symmetry with callers even though reversal is label-independent.
     γirrep = γ_list[mod1(sys.length + env.length, Nc)]
 
     sys_βs = MPI.bcast(sys.β_list, 0, comm)::Vector{SUNIrrep{Nc}}

--- a/test/test_step_helpers.jl
+++ b/test/test_step_helpers.jl
@@ -106,6 +106,8 @@ end
     balancer = SUNDMRG._density_matrix_balancer([10, 20, 30], 3, 0)
     @test length(balancer) == 3
     @test all(x -> 0 <= x < 3, balancer)
+    @test balancer == [2, 1, 0]
+    @test SUNDMRG._density_matrix_balancer([10, 20, 30], 3, 0) == balancer
 
     ρs = SUNDMRG._empty_density_matrix_vector(SUNDMRG.CPUEngine)
     @test ρs isa Vector{Matrix{Float64}}

--- a/test/test_suncalc.jl
+++ b/test/test_suncalc.jl
@@ -43,4 +43,5 @@ end
     OMself = SUNDMRG.OM_matrix([trivial3, funda3], trivial3)
     @test size(OMself) == (2, 2)
     @test OMself[1, 1] == 1
+    @test_throws ArgumentError SUNDMRG.wigner9ν(trivial3, trivial3, trivial3, trivial3, trivial3, trivial3, trivial3, trivial3, trivial3)
 end


### PR DESCRIPTION
## Summary

- Bump the package version to v1.4.7.
- Replace the stochastic density matrix balancer with deterministic greedy load assignment for reproducible MPI behavior.
- Clarify MPI broadcast contracts and add small defensive guards around Lanczos convergence, storage temp directories, SU(N > 2) on-the-fly Wigner calls, and example table loading.
- Split `Lanczos!` into smaller helpers so convergence, Ritz vector handling, reconstruction, and CG fallback are easier to review.

## Validation

- `julia --project=. -e 'using Test, SUNDMRG; include("test/test_lanczos_helpers.jl")'`
- `julia --project=. test/runtests.jl`