### PR TITLE
[codex] Fix v1.4.8 review issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.4.7"
+version = "1.4.8"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/src/api.jl
+++ b/src/api.jl
@@ -30,6 +30,7 @@ end
 
 function run_DMRG(model::HeisenbergModelSU{Nc}, lat::HoneycombLattice, m_warmup::Union{Int, Tuple{Int, Float64}}, m_sweep_list::AbstractVector, m_cooldown::Union{Int, Tuple{Int, Float64}}, engine::Type{<:Engine}; kwargs...) where Nc
     if lat.BC == :ZC
-        _run_DMRG(model, :honeycombZC, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
+        return _run_DMRG(model, :honeycombZC, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
     end
+    throw(ArgumentError("HoneycombLattice with BC=$(lat.BC) is not supported (only :ZC)"))
 end

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -2,12 +2,20 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
     correlation ∈ (:none, :nn, :chain) || throw(ArgumentError("correlation must be :none, :nn, or :chain"))
     alg ∈ (:slow, :fast) || throw(ArgumentError("alg must be :slow or :fast"))
 
-    did_init = false
+    did_init = Ref(false)
     runtime_initialized = false
     runtime_finalized = Ref(false)
     rank = 0
     if manage_mpi
-        did_init = init_DMRG!()
+        was_initialized = MPI.Initialized()
+        try
+            did_init[] = init_DMRG!()
+        catch
+            if !was_initialized && MPI.Initialized() && !MPI.Finalized()
+                finalize_DMRG!()
+            end
+            rethrow()
+        end
     elseif !MPI.Initialized() || MPI.Finalized()
         throw(ArgumentError("MPI must be initialized before run_DMRG(...; manage_mpi = false)"))
     end
@@ -24,7 +32,7 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
         if runtime_initialized && !runtime_finalized[]
             _finalize_runtime!(engine, nothing, rank)
         end
-        if manage_mpi && did_init
+        if manage_mpi && did_init[]
             finalize_DMRG!()
         end
     end

--- a/src/finite_phases.jl
+++ b/src/finite_phases.jl
@@ -54,11 +54,12 @@ function _init_state(config::_FiniteRunConfig, runtime::_FiniteRuntime)
     (; lattice, Lx, Ly, Nc, target, m_warmup, widthmax, tables, fileio, scratch, verbose) = config
     (; engine, on_the_fly, mirror, γ_type, comm, rank, Ncpu, signfactor) = runtime
 
+    storage = nothing
     m_list = Tuple{Int, Float64}[]
     errors = Float64[]
     energies = Float64[]
     EEs = Float64[]
-    EE = Vector{Float64}(undef, Lx - 1)
+    EE = fill(NaN, Lx - 1)
     ES = Dict{SUNIrrep{Nc}, Vector{Float64}}()
     SiSj = Dict{Tuple{Int, Int}, Float64}()
 
@@ -66,42 +67,49 @@ function _init_state(config::_FiniteRunConfig, runtime::_FiniteRuntime)
     tensor_table = Dict{Tuple{Symbol, Int, Int}, Matrix{Vector{Matrix{Float64}}}}()
     trmat_table = Dict{Tuple{Symbol, Int}, Vector{Matrix{Float64}}}()
 
-    if isroot(runtime)
-        storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR =
-            _init_root_state_edges(config, runtime, block_table, trmat_table, tensor_table, Val(Nc))
-    else
-        storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR =
-            _init_worker_state_edges(config, runtime, block_table, trmat_table, tensor_table, Val(Nc))
+    try
+        if isroot(runtime)
+            storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR =
+                _init_root_state_edges(config, runtime, block_table, trmat_table, tensor_table, Val(Nc))
+        else
+            storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR =
+                _init_worker_state_edges(config, runtime, block_table, trmat_table, tensor_table, Val(Nc))
+        end
+
+        blockL_enl = enlarge_block(blockL, blockL_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
+        if !mirror
+            blockR_enl = enlarge_block(blockR, blockR_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
+        else
+            blockR_enl = blockL_enl
+        end
+
+        Ψ = empty_engine_tensor_matrices(engine, mirror ? 1 : 2)
+
+        return _FiniteState{Nc,typeof(storage),typeof(blockL),typeof(blockL_tensor_dict),typeof(blockR),typeof(blockR_tensor_dict),typeof(blockL_enl),typeof(blockR_enl),typeof(trmatL),typeof(trmatR),typeof(Ψ)}(
+            m_list,
+            errors,
+            energies,
+            EEs,
+            EE,
+            ES,
+            SiSj,
+            storage,
+            blockL,
+            blockL_tensor_dict,
+            blockR,
+            blockR_tensor_dict,
+            blockL_enl,
+            blockR_enl,
+            trmatL,
+            trmatR,
+            Ψ,
+        )
+    catch
+        if storage !== nothing && isroot(runtime)
+            cleanup_storage!(storage)
+        end
+        rethrow()
     end
-
-    blockL_enl = enlarge_block(blockL, blockL_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
-    if !mirror
-        blockR_enl = enlarge_block(blockR, blockR_tensor_dict, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine; lattice = lattice)
-    else
-        blockR_enl = blockL_enl
-    end
-
-    Ψ = empty_engine_tensor_matrices(engine, mirror ? 1 : 2)
-
-    return _FiniteState{Nc,typeof(storage),typeof(blockL),typeof(blockL_tensor_dict),typeof(blockR),typeof(blockR_tensor_dict),typeof(blockL_enl),typeof(blockR_enl),typeof(trmatL),typeof(trmatR),typeof(Ψ)}(
-        m_list,
-        errors,
-        energies,
-        EEs,
-        EE,
-        ES,
-        SiSj,
-        storage,
-        blockL,
-        blockL_tensor_dict,
-        blockR,
-        blockR_tensor_dict,
-        blockL_enl,
-        blockR_enl,
-        trmatL,
-        trmatR,
-        Ψ,
-    )
 end
 
 function _init_root_state_edges(config::_FiniteRunConfig, runtime::_FiniteRuntime, block_table, trmat_table, tensor_table, ::Val{Nc}) where Nc
@@ -224,6 +232,7 @@ function _growth_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runti
     end
 
     while L < N
+        record_result = nothing
         if sys_block_enls[1].length % Ly == 0
             if verbose && isroot(runtime)
                 if mirror
@@ -243,6 +252,7 @@ function _growth_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runti
                 sys_blocks[2], sys_tensor_dicts[2], sys_block_enls[2], sys_trmats[2] = result.env_block, result.env_tensor_dict, result.env_block_enl, result.env_trmat
                 state.Ψ[2] = wavefunction_reverse(state.Ψ[1], :l, sys_blocks[1], sys_blocks[2], widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
             end
+            record_result = result
 
             _log_phase_result(runtime, verbose, result.energy, L, result.ee)
         else
@@ -286,13 +296,16 @@ function _growth_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runti
 
                 result = dmrg_step_result!(state.SiSj, sys_label, sys_blocks[i], env_block, sys_tensor_dicts[i], env_tensor_dict, sys_block_enls[i], env_block_enls[i], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); Ψ0_guess = Ψ0_guess, lattice = lattice, alg = alg, noisy = verbose && i == 1)
                 sys_blocks[i], sys_tensor_dicts[i], sys_block_enls[i], state.Ψ[i], sys_trmats[i] = result.block, result.tensor_dict, result.block_enl, result.Ψ, result.trmat
+                if i == 1
+                    record_result = result
+                end
 
                 _log_phase_result(runtime, verbose && i == 1, result.energy, L, result.ee)
             end
         end
 
         if L == N
-            state.ES = _record_step_result!(state.m_list, state.errors, state.energies, state.EEs, m_warmup, result)
+            state.ES = _record_step_result!(state.m_list, state.errors, state.energies, state.EEs, m_warmup, record_result)
         end
 
         _save_edge_blocks!(state.storage, mirror, sys_blocks[1], sys_trmats[1], sys_blocks[end], sys_trmats[end], runtime)

--- a/src/finite_sweep.jl
+++ b/src/finite_sweep.jl
@@ -51,18 +51,22 @@ function _init_sweep_state(Ψ, sys_blocks, sys_tensor_dicts, sys_trmats, sys_blo
     )
 end
 
-function _reverse_sweep_end!(state::_SweepState, Ψ0_guess, config::_FiniteRunConfig, runtime::_FiniteRuntime)
+function _swap_sweep_sides!(state::_SweepState)
+    state.sys_block, state.env_block = state.env_block, state.sys_block
+    state.sys_tensor_dict, state.env_tensor_dict = state.env_tensor_dict, state.sys_tensor_dict
+    state.sys_trmat, state.env_trmat = state.env_trmat, state.sys_trmat
+    state.sys_block_enl, state.env_block_enl = state.env_block_enl, state.sys_block_enl
+    state.sys_label, state.env_label = state.env_label, state.sys_label
+    return state
+end
+
+function _swap_if_env_exhausted!(state::_SweepState, Ψ0_guess, config::_FiniteRunConfig, runtime::_FiniteRuntime)
     (; widthmax, tables) = config
     (; comm, rank, Ncpu, on_the_fly, γ_list, engine) = runtime
 
     if state.env_block.length == 0
         Ψ0_guess = wavefunction_reverse(Ψ0_guess, state.sys_label, state.sys_block_enl, state.env_block_enl, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
-
-        state.sys_block, state.env_block = state.env_block, state.sys_block
-        state.sys_tensor_dict, state.env_tensor_dict = state.env_tensor_dict, state.sys_tensor_dict
-        state.sys_trmat, state.env_trmat = state.env_trmat, state.sys_trmat
-        state.sys_block_enl, state.env_block_enl = state.env_block_enl, state.sys_block_enl
-        state.sys_label, state.env_label = state.env_label, state.sys_label
+        _swap_sweep_sides!(state)
     end
 
     return Ψ0_guess
@@ -75,7 +79,7 @@ function _sweep_step!(SiSj, state::_SweepState, EE, storage, L, m, measurement, 
     Ψ0_guess = eig_prediction(state.Ψ0, state.sys_label, state.sys_block_enl, state.env_block_enl, state.sys_trmat, state.env_trmat, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
 
     state.env_block, state.env_tensor_dict, state.env_trmat, state.env_block_enl = _load_sweep_env(storage, state.env_label, L - state.sys_block.length - 2, config, runtime, Val(Nc))
-    Ψ0_guess = _reverse_sweep_end!(state, Ψ0_guess, config, runtime)
+    Ψ0_guess = _swap_if_env_exhausted!(state, Ψ0_guess, config, runtime)
 
     if verbose
         root_println(runtime, graphic(state.sys_block, state.env_block; sys_label = state.sys_label))
@@ -118,5 +122,5 @@ function _update_measurement_flag(measurement, energies, EEs, config::_FiniteRun
         return MPI.bcast(measurement, 0, comm)::Bool
     end
 
-    MPI.bcast(nothing, 0, comm)::Bool
+    return MPI.bcast(nothing, 0, comm)::Bool
 end

--- a/src/lanczos.jl
+++ b/src/lanczos.jl
@@ -58,6 +58,15 @@ function mycopyto!(dest::MyMatrix, src::MyMatrix)
     dest
 end
 
+function myzero!(A::MyMatrix)
+    for I in eachindex(A)
+        for J in eachindex(A[I])
+            A[I][J] .= 0.0
+        end
+    end
+    A
+end
+
 """
 CG!(A!, val, x, Ax, buffer1, buffer2, comm, rank)
 CG routine for the Lanczos method
@@ -74,6 +83,7 @@ function CG!(A!::Function, val, x, Ax, buffer1, buffer2, comm, rank)
         normold = MPI.Allreduce(mydot(r, r), MPI.SUM, comm)
         j = 1
         while true
+            myzero!(Ap)
             A!(Ap, p)
             myaxpy!(-valshift, p, Ap)
             α = normold / MPI.Allreduce(mydot(p, Ap), MPI.SUM, comm)
@@ -89,6 +99,7 @@ function CG!(A!::Function, val, x, Ax, buffer1, buffer2, comm, rank)
             j += 1
         end
         myrdiv!(x, sqrt(MPI.Allreduce(mydot(x, x), MPI.SUM, comm)))
+        myzero!(r)
         A!(r, x)
         valnew = MPI.Allreduce(mydot(x, r), MPI.SUM, comm)
         if abs((valnew - val) / valnew) < tol_wavefunction
@@ -124,6 +135,7 @@ function Lanczos!(A!::Function, initial, position, comm, rank, engine, mode::Val
     cache = _init_lanczos_cache(mode, ketk)
     k = 1
     while true
+        myzero!(ketk1)
         A!(ketk1, ketk)
         α = MPI.Allreduce(mydot(ketk, ketk1), MPI.SUM, comm)
         push!(αlist, α)
@@ -159,12 +171,7 @@ end
 
 function _zero_lanczos_vector(initial)
     ket = deepcopy(initial)
-    for I in eachindex(ket)
-        for J in eachindex(ket[I])
-            ket[I][J] .= 0.0
-        end
-    end
-    return ket
+    return myzero!(ket)
 end
 
 function _lanczos_ritz_vectors(αlist, βlist, comm, rank)
@@ -181,11 +188,7 @@ _lanczos_eigenvalue_converged(val, vold) = abs(val - vold) < tol_Lanczos * max(a
 _lanczos_wavefunction_converged(val, target_val, var) = abs(val - target_val) < tol_wavefunction * max(abs(val), 1.0) && abs(var - val ^ 2) < tol_wavefunction * max(abs(val ^ 2), 1.0)
 
 function _reconstruct_lanczos_vector!(mode::Val, A!, engine, initial, ketk, ketk1, ketkm1, vecs, αlist, βlist, position, cache)
-    for I in eachindex(ketkm1)
-        for J in eachindex(ketkm1[I])
-            ketkm1[I][J] .= 0.0
-        end
-    end
+    myzero!(ketkm1)
     mycopyto!(ketk, initial)
     β = 0.0
     position = min(position, size(vecs, 2))
@@ -198,6 +201,7 @@ end
 
 function _refine_lanczos_vector!(A!, initial, ketk, ketkm1, ketk1, target_val, comm, rank)
     myrdiv!(initial, sqrt(MPI.Allreduce(mydot(initial, initial), MPI.SUM, comm)))
+    myzero!(ketk)
     A!(ketk, initial)
     val = MPI.Allreduce(mydot(initial, ketk), MPI.SUM, comm)
     var = MPI.Allreduce(mydot(ketk, ketk), MPI.SUM, comm)
@@ -222,6 +226,7 @@ function _cache_lanczos_vector!(::Val{:fast}, cache, ketk)
 end
 
 function _lanczos_reconstruct_step!(::Val{:slow}, A!, engine, coeff, cache, initial, ketk, ketk1, ketkm1, αlist, βlist, k, β)
+    myzero!(ketk1)
     A!(ketk1, ketk)
     α = αlist[k]
     myaxpy!(-β, ketkm1, ketk1)

--- a/src/step.jl
+++ b/src/step.jl
@@ -3,7 +3,38 @@
 
 A single DMRG step, returned as a `DMRGStepResult` with explicit fields.
 """
-function dmrg_step!(SiSj, sys_label, sys::Block{Nc}, env::Block{Nc}, sys_tensor_dict, env_tensor_dict, sys_enl::EnlargedBlock{Nc}, env_enl::EnlargedBlock{Nc}, Ly, m, α, widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, ::Val{env_calc}; Ψ0_guess = nothing, ES_max = -Inf, correlation = :none, margin = 0, lattice = :square, Sj = Matrix{Vector{Matrix{Float64}}}(undef, 0, 0), alg = :slow, noisy = true) where {Nc, env_calc}
+function dmrg_step!(
+    SiSj,
+    sys_label,
+    sys::Block{Nc},
+    env::Block{Nc},
+    sys_tensor_dict,
+    env_tensor_dict,
+    sys_enl::EnlargedBlock{Nc},
+    env_enl::EnlargedBlock{Nc},
+    Ly,
+    m,
+    α,
+    widthmax,
+    target,
+    signfactor,
+    comm,
+    rank,
+    Ncpu,
+    tables,
+    on_the_fly,
+    γ_list,
+    engine,
+    ::Val{env_calc};
+    Ψ0_guess = nothing,
+    ES_max = -Inf,
+    correlation = :none,
+    margin = 0,
+    lattice = :square,
+    Sj = Matrix{Vector{Matrix{Float64}}}(undef, 0, 0),
+    alg = :slow,
+    noisy = true,
+) where {Nc, env_calc}
     workspace = _prepare_step_workspace(sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, lattice, Val(Nc))
     (; sys_αs, env_αs, sys_βs, env_βs, sys_ms, env_ms, sys_len, env_len, superblock_bonds, bonds_hold, x_conn, y_conn, sys_dp, env_dp, sys_enlarge, env_enlarge, OM, superblock_H1, superblock_H2, sys_connS, env_connS, sys_tensor_dict_hold, env_tensor_dict_hold) = workspace
 

--- a/test/test_lanczos_helpers.jl
+++ b/test/test_lanczos_helpers.jl
@@ -1,4 +1,7 @@
 using LinearAlgebra
+using MPI
+
+MPI.Initialized() || MPI.Init()
 
 @testset "Lanczos nested-array helper kernels" begin
     function nested_fixture(offset::Float64)
@@ -39,4 +42,23 @@ using LinearAlgebra
     # Copy must be value-based, not aliasing source storage.
     x[1, 1][1][1, 1] = -999.0
     @test dest[1, 1][1][1, 1] != x[1, 1][1][1, 1]
+
+    SUNDMRG.myzero!(dest)
+    for I in eachindex(dest), J in eachindex(dest[I])
+        @test iszero(dest[I][J])
+    end
+end
+
+@testset "Lanczos clears output before applying accumulating operator" begin
+    H = Diagonal([1.0, 2.0])
+    initial = Matrix{Vector{Matrix{Float64}}}(undef, 1, 1)
+    initial[1, 1] = [reshape([1.0, 1.0], 2, 1)]
+
+    function accumulating_A!(out, input)
+        out[1, 1][1] .+= H * input[1, 1][1]
+        return out
+    end
+
+    val = SUNDMRG.Lanczos!(accumulating_A!, initial, 1, MPI.COMM_SELF, 0, SUNDMRG.CPUEngine; maxiter = 4, alg = :slow)
+    @test val ≈ 1.0 atol = 1e-12
 end


### PR DESCRIPTION
## Summary

- Bump the package version to v1.4.8.
- Clear Lanczos output buffers before every in-place Hamiltonian-vector product, including CG refinement paths.
- Tighten finite-DMRG control flow around measurement broadcasts, growth result recording, scratch cleanup, and unsupported Honeycomb boundary conditions.
- Add a regression test for accumulating `A!` operators in Lanczos.

## Why

`step_lanczos.jl` can accumulate into `Ψout` during Hamiltonian-vector products. Reusing Lanczos buffers without clearing them could turn `Hψ` into `old + Hψ`, contaminating convergence and energies. The remaining updates address review findings where implicit return values, uninitialized output profiles, and broad control-flow state could hide failures.

## Validation

- `julia --project=. test/runtests.jl` passed with `236 / 236` tests.