### PR TITLE
[codex] Prepare v1.5.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## v1.5.0 - 2026-05-11
+
+### Changed
+
+- Refactored the finite DMRG workflow into smaller internal phase, step, runtime, and workspace helpers.
+- Refactored DMRG step and finite-state flow to improve maintainability.
+- Replaced long internal DMRG step call sites with structured step request objects.
+- Moved MPI lifecycle handling behind `init_DMRG!` and `finalize_DMRG!`, with `run_DMRG` supporting externally managed MPI sessions.
+- Added engine-specific allocation helpers and a storage adapter for DMRG block/tensor IO.
+- Improved type stability across the DMRG runtime.
+- Switched DMRG wavefunction dot products to the local `mydot` helper.
+
+### Fixed
+
+- Fixed precompilation involving CUDA memory type references.
+- Fixed SUNIrrep compatibility in `Block` irrep vector typing.
+- Fixed SU ambiguity tests and explicit SUNIrrep rank usage.
+- Fixed mirror initialization placeholders for right blocks and transfer matrices.
+- Fixed missing warmup bond dimension propagation during initialization.
+- Fixed growth-phase type parameter capture and generalized `dcinit` invariant tests.
+
+### Tests
+
+- Added and expanded CPU-only unit tests for initialization, step, Lanczos, table, storage, SU helper, sparse vector, and on-the-fly helper functionality.
+- Updated README testing notes and TODO entries.
+
+### Documentation
+
+- Added an initial Documenter.jl documentation scaffold.
+- Added an SU(Nc) representation theory overview.
+- Added concrete SU(2), SU(3), and SU(4) representation examples.
+- Added a general DMRG overview page.
+- Updated citation and README content.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.4.8"
+version = "1.5.0"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SUNDMRG = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
+
+[sources]
+SUNDMRG = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,18 @@
+push!(LOAD_PATH, joinpath(@__DIR__, "..", "src"))
+
+using Documenter
+using SUNDMRG
+
+makedocs(;
+    sitename = "SUNDMRG.jl",
+    modules = [SUNDMRG],
+    checkdocs = :none,
+    format = Documenter.HTML(; prettyurls = false),
+    pages = [
+        "Home" => "index.md",
+        "DMRG Overview" => "dmrg_overview.md",
+        "SU(Nc) Representation Theory" => "representation_theory.md",
+        "Examples of SU(Nc) Representations" => "su_n_examples.md",
+        "Representation Labels in SUNDMRG.jl" => "representation_notation.md",
+    ],
+)

--- a/docs/src/dmrg_overview.md
+++ b/docs/src/dmrg_overview.md
@@ -1,0 +1,124 @@
+# DMRG Overview
+
+The density matrix renormalization group (DMRG) is a variational method for finding low-energy states of quantum many-body systems.
+It is especially effective when the target state has limited entanglement across spatial cuts.
+
+This page gives a high-level overview of the method.
+It avoids package-specific input syntax and focuses on the general algorithmic picture.
+
+## Variational Idea
+
+The exact Hilbert space of a many-body system grows exponentially with system size.
+DMRG works by keeping only the most relevant states for describing the target wavefunction across a bipartition.
+
+The central approximation is controlled by a bond dimension ``m``.
+Larger ``m`` allows more entanglement and usually gives more accurate results, but increases memory use and computational cost.
+
+At a cut dividing the system into left and right parts, a wavefunction can be written in Schmidt form:
+
+```math
+|\psi\rangle
+  =
+  \sum_i s_i\, |i\rangle_L \otimes |i\rangle_R.
+```
+
+The Schmidt values ``s_i`` quantify the entanglement across the cut.
+DMRG keeps the most important Schmidt sectors and discards the rest.
+
+## Reduced Density Matrix
+
+The name DMRG comes from the reduced density matrix used to choose the truncated basis.
+Given a normalized wavefunction ``|\psi\rangle`` for a bipartition, the reduced density matrix of the left subsystem is
+
+```math
+\rho_L = \mathrm{Tr}_R |\psi\rangle\langle\psi|.
+```
+
+Its eigenvalues measure how much weight each left-subsystem state carries in the full wavefunction.
+Keeping the eigenvectors with the largest eigenvalues gives an optimal truncated basis for that bipartition in the least-squares sense.
+
+The discarded weight is often used as a truncation error estimate:
+
+```math
+\epsilon = \sum_{i > m} \lambda_i,
+```
+
+where ``\lambda_i`` are the density-matrix eigenvalues sorted in descending order.
+
+## Blocks And Superblocks
+
+Traditional finite-system DMRG describes the system using blocks.
+A typical step builds a superblock from a system block, one or more active sites, and an environment block.
+The target state of this superblock is obtained by solving an effective eigenvalue problem.
+
+Conceptually, one step does the following:
+
+1. Build an effective Hamiltonian for the current superblock.
+2. Solve for the target state, usually the ground state or a low-lying state.
+3. Form a reduced density matrix for the side being enlarged.
+4. Diagonalize the reduced density matrix.
+5. Keep the most important ``m`` states.
+6. Transform operators into the new truncated basis.
+
+The result is a new block that approximates a larger part of the system.
+
+## Warmup And Sweeps
+
+Finite-system DMRG is usually organized into two stages.
+
+During the warmup stage, the algorithm grows blocks until the desired system size is reached.
+The environment may be approximate during this stage.
+
+During the sweep stage, the system size is fixed.
+The algorithm moves the active cut back and forth through the system, alternately improving the left and right block bases.
+Each sweep refines the variational state using a better environment.
+
+Sweeps continue until observables, energy, or entanglement quantities converge to the desired tolerance.
+
+## Entanglement Entropy
+
+The Schmidt values also define the entanglement entropy across a cut.
+If ``\lambda_i = s_i^2`` are the eigenvalues of the reduced density matrix, the von Neumann entanglement entropy is
+
+```math
+S = -\sum_i \lambda_i \log \lambda_i.
+```
+
+Entanglement entropy is useful both as a physical observable and as a diagnostic of how difficult a calculation is.
+Large entanglement generally requires a larger bond dimension.
+
+## Symmetry Sectors
+
+When a Hamiltonian has a symmetry, the Hilbert space decomposes into symmetry sectors.
+DMRG can exploit this by organizing basis states and operators according to conserved quantum numbers or irreducible representations.
+
+In a symmetry-adapted calculation, the reduced density matrix is block diagonal in symmetry sectors.
+The truncation then keeps important states across sectors while preserving the symmetry structure.
+
+For non-Abelian symmetries such as SU(Nc), states are grouped by irreducible representations rather than only by Abelian charges.
+The representation-theory pages in this manual describe the notation used for those labels.
+
+## Accuracy Controls
+
+The most important numerical controls in a DMRG calculation are:
+
+- the bond dimension ``m``;
+- the truncation error or discarded weight;
+- the number of sweeps;
+- convergence thresholds for energy and observables;
+- the quality of the effective eigensolver.
+
+Increasing ``m`` is the most direct way to improve the variational space.
+However, a larger ``m`` also increases the cost of tensor contractions, operator transformations, and effective Hamiltonian applications.
+
+## MPS Perspective
+
+Modern presentations often describe DMRG as a variational optimization over matrix product states (MPS).
+In that language, a sweep optimizes local tensors while keeping the rest of the MPS fixed.
+
+Traditional block DMRG and MPS DMRG are closely related views of the same variational principle.
+The block language emphasizes renormalized bases and effective operators, while the MPS language emphasizes tensor networks and canonical forms.
+
+Both perspectives are useful.
+The rest of this documentation will use whichever viewpoint makes the relevant part of SUNDMRG.jl easiest to explain.
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,17 @@
+# SUNDMRG.jl
+
+SUNDMRG.jl is a DMRG implementation with full SU(N) symmetry.
+
+This documentation starts with the representation-theoretic background used by the package.
+
+```@contents
+Pages = ["dmrg_overview.md", "representation_theory.md", "su_n_examples.md", "representation_notation.md"]
+Depth = 2
+```
+
+## Reading Path
+
+Start with [DMRG Overview](dmrg_overview.md) for the general algorithmic ideas.
+Then read [SU(Nc) Representation Theory](representation_theory.md) for the symmetry notation used in SU(Nc)-adapted calculations.
+Continue to [Examples of SU(Nc) Representations](su_n_examples.md) for concrete labels and small tensor-product decompositions.
+The short [Representation Labels in SUNDMRG.jl](representation_notation.md) note records the row-length convention used when labels appear in package-facing contexts.

--- a/docs/src/representation_notation.md
+++ b/docs/src/representation_notation.md
@@ -1,0 +1,22 @@
+# Representation Labels In SUNDMRG.jl
+
+SUNDMRG.jl follows the Young row-length convention for SU(Nc) representation labels.
+When labels appear in package-facing contexts, trailing zeros may be retained so that the tuple length is ``N_c``.
+
+For example, in SU(3):
+
+| Representation | Mathematical row lengths | Package-facing label |
+|:---------------|:-------------------------|:---------------------|
+| singlet | ``()`` | ``(0, 0, 0)`` |
+| fundamental | ``(1)`` | ``(1, 0, 0)`` |
+| antifundamental | ``(1, 1)`` | ``(1, 1, 0)`` |
+| adjoint | ``(2, 1)`` | ``(2, 1, 0)`` |
+
+Dynkin labels are obtained from adjacent differences:
+
+```math
+a_i = \lambda_i - \lambda_{i+1}.
+```
+
+Thus the SU(3) label ``(2,1,0)`` corresponds to Dynkin label ``[1,1]``.
+

--- a/docs/src/representation_theory.md
+++ b/docs/src/representation_theory.md
@@ -1,0 +1,174 @@
+# SU(Nc) Representation Theory
+
+This page summarizes the representation-theoretic notation used by SUNDMRG.jl.
+It deliberately stays at the level of SU(Nc) representation theory and does not discuss the DMRG algorithm.
+
+The main objects are irreducible representations, Young diagrams, Dynkin labels, tensor-product decompositions, conjugate representations, singlets, and the general structure of symmetry-adapted matrix elements.
+
+## SU(Nc) And Irreducible Representations
+
+SU(Nc) is the Lie group of ``N_c \times N_c`` unitary matrices with determinant one.
+Its Lie algebra ``\mathfrak{su}(N_c)`` has ``N_c^2 - 1`` generators.
+
+A vector space used in a quantum many-body problem often carries a representation of SU(Nc).
+This means that each group element ``g \in SU(N_c)`` acts as a linear map ``D(g): V \to V``.
+An irreducible representation is a representation that cannot be decomposed into smaller nontrivial invariant subspaces.
+
+Finite-dimensional irreducible representations of SU(Nc) can be labeled by highest weights, Dynkin labels, or Young diagrams.
+These are equivalent descriptions of the same objects, but each is convenient for a different calculation.
+
+## Fundamental Representation
+
+The fundamental representation of SU(Nc) has dimension ``N_c``.
+In Young-diagram notation it is represented by a single box.
+In this documentation we describe Young diagrams by their row lengths, so the fundamental representation is written as ``(1)``.
+
+The conjugate of the fundamental representation is the antifundamental representation.
+For SU(2), the fundamental and antifundamental representations are equivalent.
+For SU(Nc) with ``N_c > 2``, they are generally distinct.
+
+## Young Diagrams
+
+A Young diagram is a left-justified collection of boxes arranged in rows.
+Let the row lengths be
+
+```math
+\lambda_1 \ge \lambda_2 \ge \cdots \ge \lambda_{N_c - 1} \ge 0.
+```
+
+Then ``(\lambda_1, \lambda_2, \ldots, \lambda_{N_c-1})`` labels an SU(Nc) irreducible representation.
+For SU(Nc), a column of height ``N_c`` is equivalent to the trivial representation and can be removed, so one only needs diagrams with at most ``N_c - 1`` rows.
+
+Young diagrams encode two elementary symmetrization rules:
+
+- Indices in the same row are symmetrized.
+- Indices in the same column are antisymmetrized.
+
+For example, the tensor product of two fundamental representations decomposes into a symmetric two-box representation and an antisymmetric two-box representation:
+
+```math
+\mathbf{N_c} \otimes \mathbf{N_c}
+  = \mathrm{Sym}^2(\mathbf{N_c}) \oplus \wedge^2(\mathbf{N_c}).
+```
+
+In row-length notation, these are ``(2)`` and ``(1, 1)``.
+
+## Dynkin Labels
+
+The Dynkin labels ``[a_1, a_2, \ldots, a_{N_c-1}]`` are related to Young-diagram row lengths by
+
+```math
+a_i = \lambda_i - \lambda_{i+1},
+```
+
+with ``\lambda_{N_c} = 0``.
+Conversely,
+
+```math
+\lambda_i = \sum_{j=i}^{N_c-1} a_j.
+```
+
+For SU(3), Dynkin labels are often written as ``[p, q]``.
+The fundamental representation is ``[1, 0]``, the antifundamental representation is ``[0, 1]``, and the adjoint representation is ``[1, 1]``.
+
+## Dimension Formula
+
+The dimension of the SU(Nc) irreducible representation associated with a Young diagram ``\lambda`` is given by the hook-length formula.
+For a box ``(i, j)`` in row ``i`` and column ``j``, let ``h(i,j)`` be its hook length.
+Then
+
+```math
+\dim(\lambda)
+  = \prod_{(i,j) \in \lambda}
+    \frac{N_c + j - i}{h(i,j)}.
+```
+
+This gives ``\dim(1) = N_c`` for the fundamental representation and ``N_c(N_c-1)/2`` for the two-index antisymmetric representation ``(1,1)``.
+
+## Tensor-Product Decomposition
+
+When two SU(Nc) representation spaces are combined, their tensor product decomposes into a direct sum of irreducible representations:
+
+```math
+\alpha \otimes \beta
+  = \bigoplus_{\gamma} N_{\alpha\beta}^{\gamma}\, \gamma.
+```
+
+The integer ``N_{\alpha\beta}^{\gamma}`` is a Littlewood-Richardson coefficient.
+It counts how many times the irreducible representation ``\gamma`` appears in the tensor product ``\alpha \otimes \beta``.
+
+Tensoring with the fundamental representation can be understood as adding one box to a Young diagram.
+The resulting diagram must still have nonincreasing row lengths, and any column of height ``N_c`` can be removed according to the SU(Nc) equivalence.
+
+## Conjugate Representations
+
+The conjugate representation ``\lambda^\ast`` reverses the SU(Nc) weight structure.
+In Dynkin-label notation, conjugation reverses the order of the labels:
+
+```math
+[a_1, a_2, \ldots, a_{N_c-1}]^\ast
+  = [a_{N_c-1}, \ldots, a_2, a_1].
+```
+
+For SU(3), this gives ``[1,0]^\ast = [0,1]``.
+For SU(2), there is only one Dynkin label, so every irreducible representation is self-conjugate.
+
+## Singlet Condition
+
+The trivial representation, or singlet, is denoted by ``\mathbf{1}``.
+Singlets are important because they are invariant under the full SU(Nc) action.
+
+A basic singlet relation is
+
+```math
+\alpha \otimes \alpha^\ast \supset \mathbf{1}.
+```
+
+More generally, deciding whether a product of representations can form an invariant state is a question about whether the trivial representation appears in the corresponding tensor-product decomposition.
+
+## Irreducible Tensor Operators
+
+Operators can also be classified by how they transform under SU(Nc).
+An operator transforming as an irreducible representation ``\gamma`` is an irreducible tensor operator.
+Its matrix elements have a Wigner-Eckart type structure:
+
+```math
+\langle \alpha' m' | T^{(\gamma)}_\mu | \alpha m \rangle
+  =
+  \sum_{\tau}
+  C^{\alpha' m'}_{\alpha m, \gamma \mu; \tau}
+  \langle \alpha' || T^{(\gamma)} || \alpha \rangle_{\tau}.
+```
+
+Here ``C`` is a Clebsch-Gordan coefficient, and ``\tau`` labels outer multiplicities when the same irreducible representation appears more than once.
+The reduced matrix element ``\langle \alpha' || T^{(\gamma)} || \alpha \rangle_{\tau}`` contains the part that is not fixed by symmetry alone.
+
+## Relation To SU(2)
+
+For SU(2), irreducible representations are labeled by spin ``S`` and have dimension ``2S + 1``.
+The SU(2) Dynkin label ``[a]`` is related to spin by
+
+```math
+a = 2S.
+```
+
+The familiar angular-momentum addition rule
+
+```math
+S_1 \otimes S_2
+  =
+  |S_1 - S_2| \oplus \cdots \oplus (S_1 + S_2)
+```
+
+is the simplest example of tensor-product decomposition.
+For SU(Nc), the rank is ``N_c - 1``, so representation labels, multiplicities, and Clebsch-Gordan structures become richer.
+
+## Notation Summary
+
+- ``N_c`` is the dimension of the fundamental representation, not the rank of SU(Nc).
+- ``\alpha, \beta, \gamma`` denote irreducible SU(Nc) representations.
+- ``\alpha \otimes \beta`` denotes a tensor product of representations.
+- ``N_{\alpha\beta}^{\gamma}`` is a Littlewood-Richardson coefficient.
+- ``\alpha^\ast`` denotes the conjugate representation of ``\alpha``.
+- ``\mathbf{1}`` denotes the trivial representation, also called a singlet.
+

--- a/docs/src/su_n_examples.md
+++ b/docs/src/su_n_examples.md
@@ -1,0 +1,218 @@
+# Examples of SU(Nc) Representations
+
+This page collects small SU(Nc) examples that make the notation in [SU(Nc) Representation Theory](representation_theory.md) more concrete.
+It focuses on representation labels and tensor-product decompositions, not on algorithms.
+
+## Reading The Labels
+
+An SU(Nc) irreducible representation can be written in several equivalent ways.
+The three most common forms are:
+
+- a Young diagram, described here by row lengths such as ``(2,1)``;
+- a Dynkin label such as ``[1,1,0]``;
+- a dimension name such as ``\mathbf{3}``, ``\mathbf{8}``, or ``\mathbf{15}`` when the context is clear.
+
+Dimension names are convenient but not unique across different groups.
+For example, ``\mathbf{6}`` in SU(3) and ``\mathbf{6}`` in SU(4) refer to different representation-theoretic objects.
+Dynkin labels and Young-diagram row lengths are usually safer.
+
+## SU(2)
+
+SU(2) has rank one, so each irreducible representation has a single Dynkin label ``[a]``.
+It corresponds to spin
+
+```math
+S = \frac{a}{2},
+```
+
+and has dimension
+
+```math
+\dim[a] = a + 1 = 2S + 1.
+```
+
+Some common SU(2) representations are:
+
+| Spin ``S`` | Dynkin label | Dimension |
+|:----------:|:------------:|:---------:|
+| ``0`` | ``[0]`` | ``1`` |
+| ``1/2`` | ``[1]`` | ``2`` |
+| ``1`` | ``[2]`` | ``3`` |
+| ``3/2`` | ``[3]`` | ``4`` |
+
+The familiar tensor-product rule is
+
+```math
+S_1 \otimes S_2
+  =
+  |S_1 - S_2| \oplus \cdots \oplus (S_1 + S_2).
+```
+
+For example,
+
+```math
+\mathbf{2} \otimes \mathbf{2}
+  =
+  \mathbf{1} \oplus \mathbf{3}.
+```
+
+In Dynkin labels, this is
+
+```math
+[1] \otimes [1] = [0] \oplus [2].
+```
+
+## SU(3)
+
+SU(3) has rank two, so irreducible representations are labeled by ``[p,q]``.
+The corresponding Young-diagram row lengths are
+
+```math
+(\lambda_1,\lambda_2) = (p + q, q).
+```
+
+Some common SU(3) representations are:
+
+| Name | Dynkin label | Row lengths | Dimension |
+|:-----|:-------------|:------------|----------:|
+| singlet | ``[0,0]`` | ``()`` | ``1`` |
+| fundamental | ``[1,0]`` | ``(1)`` | ``3`` |
+| antifundamental | ``[0,1]`` | ``(1,1)`` | ``3`` |
+| adjoint | ``[1,1]`` | ``(2,1)`` | ``8`` |
+| two-index symmetric | ``[2,0]`` | ``(2)`` | ``6`` |
+| two-index antisymmetric | ``[0,1]`` | ``(1,1)`` | ``3`` |
+
+The most useful small decompositions are:
+
+```math
+\mathbf{3} \otimes \mathbf{3}
+  =
+  \mathbf{6} \oplus \bar{\mathbf{3}},
+```
+
+```math
+\mathbf{3} \otimes \bar{\mathbf{3}}
+  =
+  \mathbf{1} \oplus \mathbf{8}.
+```
+
+In Dynkin labels,
+
+```math
+[1,0] \otimes [1,0]
+  =
+  [2,0] \oplus [0,1],
+```
+
+```math
+[1,0] \otimes [0,1]
+  =
+  [0,0] \oplus [1,1].
+```
+
+The second decomposition shows explicitly how a fundamental and an antifundamental can form a singlet.
+
+## SU(4)
+
+SU(4) has rank three, so irreducible representations are labeled by ``[a,b,c]``.
+The corresponding Young-diagram row lengths are
+
+```math
+(\lambda_1,\lambda_2,\lambda_3)
+  =
+  (a + b + c, b + c, c).
+```
+
+Some common SU(4) representations are:
+
+| Name | Dynkin label | Row lengths | Dimension |
+|:-----|:-------------|:------------|----------:|
+| singlet | ``[0,0,0]`` | ``()`` | ``1`` |
+| fundamental | ``[1,0,0]`` | ``(1)`` | ``4`` |
+| antifundamental | ``[0,0,1]`` | ``(1,1,1)`` | ``4`` |
+| two-index antisymmetric | ``[0,1,0]`` | ``(1,1)`` | ``6`` |
+| two-index symmetric | ``[2,0,0]`` | ``(2)`` | ``10`` |
+| adjoint | ``[1,0,1]`` | ``(2,1,1)`` | ``15`` |
+
+The fundamental tensor products include:
+
+```math
+\mathbf{4} \otimes \mathbf{4}
+  =
+  \mathbf{10} \oplus \mathbf{6},
+```
+
+```math
+\mathbf{4} \otimes \bar{\mathbf{4}}
+  =
+  \mathbf{1} \oplus \mathbf{15}.
+```
+
+In Dynkin labels,
+
+```math
+[1,0,0] \otimes [1,0,0]
+  =
+  [2,0,0] \oplus [0,1,0],
+```
+
+```math
+[1,0,0] \otimes [0,0,1]
+  =
+  [0,0,0] \oplus [1,0,1].
+```
+
+## Adjoint Representation
+
+For SU(Nc), the adjoint representation has dimension
+
+```math
+N_c^2 - 1.
+```
+
+Its Dynkin label is
+
+```math
+[1,0,\ldots,0,1],
+```
+
+for ``N_c > 2``.
+For SU(2), the adjoint representation is the spin-1 representation ``[2]``.
+
+The adjoint representation appears in the decomposition
+
+```math
+\mathbf{N_c} \otimes \bar{\mathbf{N_c}}
+  =
+  \mathbf{1} \oplus \mathrm{Adj}.
+```
+
+This identity is one of the most common ways to recognize the singlet and adjoint sectors.
+
+## Conjugation Examples
+
+Conjugation reverses Dynkin labels:
+
+```math
+[a_1,a_2,\ldots,a_{N_c-1}]^\ast
+  =
+  [a_{N_c-1},\ldots,a_2,a_1].
+```
+
+Examples:
+
+| Group | Representation | Conjugate |
+|:------|:---------------|:----------|
+| SU(2) | ``[a]`` | ``[a]`` |
+| SU(3) | ``[1,0]`` | ``[0,1]`` |
+| SU(3) | ``[2,0]`` | ``[0,2]`` |
+| SU(4) | ``[1,0,0]`` | ``[0,0,1]`` |
+| SU(4) | ``[0,1,0]`` | ``[0,1,0]`` |
+
+The SU(4) two-index antisymmetric representation ``[0,1,0]`` is self-conjugate.
+
+## Practical Caution
+
+Dimension labels are compact, but they can hide important distinctions.
+When writing implementation notes or checking decompositions, prefer Dynkin labels or row lengths unless the group and convention are completely clear.
+

--- a/src/finite_phases.jl
+++ b/src/finite_phases.jl
@@ -176,9 +176,9 @@ function _init_worker_state_edges(config::_FiniteRunConfig, runtime::_FiniteRunt
     return storage, blockL, blockL_tensor_dict, trmatL, blockR, blockR_tensor_dict, trmatR
 end
 
-function _warmup_phase!(state::_FiniteState, config::_FiniteRunConfig, runtime::_FiniteRuntime)
-    (; lattice, Ly, N, m_warmup, widthmax, target, tables, alg, verbose) = config
-    (; engine, comm, rank, Ncpu, on_the_fly, mirror, γ_list, signfactor) = runtime
+function _warmup_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runtime::_FiniteRuntime) where Nc
+    (; Ly, N, m_warmup, verbose) = config
+    (; mirror) = runtime
 
     while state.blockL.length < Ly
         if verbose && isroot(runtime)
@@ -190,10 +190,14 @@ function _warmup_phase!(state::_FiniteState, config::_FiniteRunConfig, runtime::
         end
 
         if mirror
-            result = dmrg_step_result!(state.SiSj, :l, state.blockL, state.blockL, state.blockL_tensor_dict, state.blockL_tensor_dict, state.blockL_enl, state.blockL_enl, Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); lattice = lattice, alg = alg, noisy = verbose)
+            blocks = _dmrg_step_blocks(:l, state.blockL, state.blockL, state.blockL_tensor_dict, state.blockL_tensor_dict, state.blockL_enl, state.blockL_enl)
+            request = _dmrg_step_request(blocks, m_warmup, Val(false); noisy = verbose)
+            result = dmrg_step_result!(state.SiSj, request, config, runtime, Val(Nc))
             _apply_left_step_result!(state, result)
         else
-            result = dmrg_step_result!(state.SiSj, :l, state.blockL, state.blockR, state.blockL_tensor_dict, state.blockR_tensor_dict, state.blockL_enl, state.blockR_enl, Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(true); lattice = lattice, alg = alg, noisy = verbose)
+            blocks = _dmrg_step_blocks(:l, state.blockL, state.blockR, state.blockL_tensor_dict, state.blockR_tensor_dict, state.blockL_enl, state.blockR_enl)
+            request = _dmrg_step_request(blocks, m_warmup, Val(true); noisy = verbose)
+            result = dmrg_step_result!(state.SiSj, request, config, runtime, Val(Nc))
             _apply_left_step_result!(state, result)
             _apply_mirror_env_result!(state, result, config, runtime)
         end
@@ -210,7 +214,7 @@ function _warmup_phase!(state::_FiniteState, config::_FiniteRunConfig, runtime::
 end
 
 function _growth_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runtime::_FiniteRuntime) where Nc
-    (; lattice, Ly, N, m_warmup, widthmax, target, tables, alg, verbose) = config
+    (; lattice, Ly, N, m_warmup, widthmax, tables, verbose) = config
     (; engine, comm, rank, Ncpu, on_the_fly, mirror, γ_type, γ_list, signfactor) = runtime
 
     L = 2state.blockL.length
@@ -244,10 +248,14 @@ function _growth_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runti
 
             L = 2sys_block_enls[1].length
             if mirror
-                result = dmrg_step_result!(state.SiSj, :l, sys_blocks[1], sys_blocks[1], sys_tensor_dicts[1], sys_tensor_dicts[1], sys_block_enls[1], sys_block_enls[1], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); lattice = lattice, alg = alg, noisy = verbose)
+                blocks = _dmrg_step_blocks(:l, sys_blocks[1], sys_blocks[1], sys_tensor_dicts[1], sys_tensor_dicts[1], sys_block_enls[1], sys_block_enls[1])
+                request = _dmrg_step_request(blocks, m_warmup, Val(false); noisy = verbose)
+                result = dmrg_step_result!(state.SiSj, request, config, runtime, Val(Nc))
                 sys_blocks[1], sys_tensor_dicts[1], sys_block_enls[1], state.Ψ[1], sys_trmats[1] = result.block, result.tensor_dict, result.block_enl, result.Ψ, result.trmat
             else
-                result = dmrg_step_result!(state.SiSj, :l, sys_blocks[1], sys_blocks[2], sys_tensor_dicts[1], sys_tensor_dicts[2], sys_block_enls[1], sys_block_enls[2], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(true); lattice = lattice, alg = alg, noisy = verbose)
+                blocks = _dmrg_step_blocks(:l, sys_blocks[1], sys_blocks[2], sys_tensor_dicts[1], sys_tensor_dicts[2], sys_block_enls[1], sys_block_enls[2])
+                request = _dmrg_step_request(blocks, m_warmup, Val(true); noisy = verbose)
+                result = dmrg_step_result!(state.SiSj, request, config, runtime, Val(Nc))
                 sys_blocks[1], sys_tensor_dicts[1], sys_block_enls[1], state.Ψ[1], sys_trmats[1] = result.block, result.tensor_dict, result.block_enl, result.Ψ, result.trmat
                 sys_blocks[2], sys_tensor_dicts[2], sys_block_enls[2], sys_trmats[2] = result.env_block, result.env_tensor_dict, result.env_block_enl, result.env_trmat
                 state.Ψ[2] = wavefunction_reverse(state.Ψ[1], :l, sys_blocks[1], sys_blocks[2], widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
@@ -294,7 +302,9 @@ function _growth_phase!(state::_FiniteState{Nc}, config::_FiniteRunConfig, runti
                     root_println(runtime, graphic(sys_blocks[i], env_block; sys_label = sys_label))
                 end
 
-                result = dmrg_step_result!(state.SiSj, sys_label, sys_blocks[i], env_block, sys_tensor_dicts[i], env_tensor_dict, sys_block_enls[i], env_block_enls[i], Ly, m_warmup..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); Ψ0_guess = Ψ0_guess, lattice = lattice, alg = alg, noisy = verbose && i == 1)
+                blocks = _dmrg_step_blocks(sys_label, sys_blocks[i], env_block, sys_tensor_dicts[i], env_tensor_dict, sys_block_enls[i], env_block_enls[i])
+                request = _dmrg_step_request(blocks, m_warmup, Val(false); Ψ0_guess = Ψ0_guess, noisy = verbose && i == 1)
+                result = dmrg_step_result!(state.SiSj, request, config, runtime, Val(Nc))
                 sys_blocks[i], sys_tensor_dicts[i], sys_block_enls[i], state.Ψ[i], sys_trmats[i] = result.block, result.tensor_dict, result.block_enl, result.Ψ, result.trmat
                 if i == 1
                     record_result = result

--- a/src/finite_support.jl
+++ b/src/finite_support.jl
@@ -11,3 +11,38 @@ function graphic(sys_block, env_block; sys_label = :l)
     end
     str
 end
+
+function _dmrg_step_blocks(sys_label, sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl)
+    _DMRGStepBlocks(sys_label, sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl)
+end
+
+function _dmrg_step_settings(config::_FiniteRunConfig, runtime::_FiniteRuntime)
+    (; Ly, widthmax, target, tables, alg, lattice) = config
+    (; signfactor, on_the_fly, γ_list) = runtime
+    _DMRGStepSettings(Ly, widthmax, target, signfactor, tables, on_the_fly, γ_list, alg, lattice)
+end
+
+function _dmrg_step_runtime(runtime::_FiniteRuntime)
+    (; comm, rank, Ncpu, engine) = runtime
+    _DMRGStepRuntime(comm, rank, Ncpu, engine)
+end
+
+function _dmrg_step_request(
+    blocks,
+    schedule::_DMRGSchedule,
+    ::Val{env_calc};
+    Ψ0_guess = nothing,
+    ES_max = -Inf,
+    correlation = Val(:none),
+    margin = 0,
+    Sj = Matrix{Vector{Matrix{Float64}}}(undef, 0, 0),
+    noisy = true,
+) where env_calc
+    m, α = schedule
+    options = _DMRGStepOptions(Ψ0_guess, ES_max, correlation, margin, Sj, noisy)
+    _DMRGStepRequest(blocks, _DMRGStepSchedule(m, α), options, Val(env_calc))
+end
+
+function dmrg_step_result!(SiSj, request::_DMRGStepRequest, config::_FiniteRunConfig, runtime::_FiniteRuntime, ::Val{Nc}) where Nc
+    dmrg_step!(SiSj, request, _dmrg_step_settings(config, runtime), _dmrg_step_runtime(runtime), Val(Nc))
+end

--- a/src/finite_sweep.jl
+++ b/src/finite_sweep.jl
@@ -73,8 +73,8 @@ function _swap_if_env_exhausted!(state::_SweepState, Ψ0_guess, config::_FiniteR
 end
 
 function _sweep_step!(SiSj, state::_SweepState, EE, storage, L, m, measurement, config::_FiniteRunConfig, runtime::_FiniteRuntime, ::Val{Nc}) where Nc
-    (; lattice, Ly, widthmax, target, tables, alg, correlation, margin, ES_max, verbose) = config
-    (; engine, comm, rank, Ncpu, on_the_fly, γ_list, signfactor) = runtime
+    (; Ly, widthmax, tables, correlation, margin, ES_max, verbose) = config
+    (; engine, comm, rank, Ncpu, on_the_fly, γ_list) = runtime
 
     Ψ0_guess = eig_prediction(state.Ψ0, state.sys_label, state.sys_block_enl, state.env_block_enl, state.sys_trmat, state.env_trmat, widthmax, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine)
 
@@ -86,7 +86,9 @@ function _sweep_step!(SiSj, state::_SweepState, EE, storage, L, m, measurement, 
     end
 
     cor = measurement && (state.sys_label == :r || state.sys_block.length == 0) ? correlation : Val(:none)
-    result = dmrg_step_result!(SiSj, state.sys_label, state.sys_block, state.env_block, state.sys_tensor_dict, state.env_tensor_dict, state.sys_block_enl, state.env_block_enl, Ly, m..., widthmax, target, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, Val(false); Ψ0_guess = Ψ0_guess, ES_max = ES_max, correlation = cor, margin = margin, lattice = lattice, Sj = state.Sj, alg = alg, noisy = verbose)
+    blocks = _dmrg_step_blocks(state.sys_label, state.sys_block, state.env_block, state.sys_tensor_dict, state.env_tensor_dict, state.sys_block_enl, state.env_block_enl)
+    request = _dmrg_step_request(blocks, m, Val(false); Ψ0_guess = Ψ0_guess, ES_max = ES_max, correlation = cor, margin = margin, Sj = state.Sj, noisy = verbose)
+    result = dmrg_step_result!(SiSj, request, config, runtime, Val(Nc))
     state.sys_block = result.block
     state.sys_tensor_dict = result.tensor_dict
     state.sys_block_enl = result.block_enl

--- a/src/step.jl
+++ b/src/step.jl
@@ -1,8 +1,130 @@
 """
-    dmrg_step!(...)
+    dmrg_step!(SiSj, request, settings, runtime, Val(Nc))
 
 A single DMRG step, returned as a `DMRGStepResult` with explicit fields.
 """
+function dmrg_step!(
+    SiSj,
+    request::_DMRGStepRequest{env_calc},
+    settings::_DMRGStepSettings,
+    runtime::_DMRGStepRuntime,
+    ::Val{Nc},
+) where {Nc, env_calc}
+    (; blocks, schedule, options) = request
+    (; sys_label, sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl) = blocks
+    (; m, α) = schedule
+    (; Ly, widthmax, target, signfactor, tables, on_the_fly, γ_list, alg, lattice) = settings
+    (; comm, rank, Ncpu, engine) = runtime
+    (; Ψ0_guess, ES_max, correlation, margin, noisy) = options
+    Sj = options.Sj
+
+    workspace = _prepare_step_workspace(sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, lattice, Val(Nc))
+    (; sys_αs, env_αs, sys_βs, env_βs, sys_ms, env_ms, sys_len, env_len, superblock_bonds, bonds_hold, x_conn, y_conn, sys_dp, env_dp, sys_enlarge, env_enlarge, OM, superblock_H1, superblock_H2, sys_connS, env_connS, sys_tensor_dict_hold, env_tensor_dict_hold) = workspace
+
+    Ψ0 = _initial_step_wavefunction(Ψ0_guess, env_ms, sys_ms, OM, Ncpu, rank, engine)
+    lanczos_context = _StepLanczosContext(target, comm, rank, engine, alg, superblock_H1, bonds_hold, x_conn, y_conn, sys_connS, env_connS, sys_ms, env_ms, sys_βs, env_βs, sys_dp, env_dp, sys_enlarge, env_enlarge, sys_tensor_dict_hold, env_tensor_dict_hold, superblock_H2, OM, sys_len, env_len, Ncpu)
+    E, time_Lanczos = _run_step_lanczos!(Ψ0, lanczos_context)
+    energy = _step_energy(E, time_Lanczos, sys_enl, env_enl, superblock_bonds, comm, rank, noisy, Val(Nc))
+    density_context = _StepDensityContext(comm, rank, Ncpu, engine, α, m, ES_max, noisy)
+    measurement_context = _StepMeasurementContext(SiSj, Ly, x_conn, y_conn, sys_connS, env_connS, sys_len, env_len, sys_tensor_dict, env_tensor_dict, sys_tensor_dict_hold, env_tensor_dict_hold, sys_αs, env_αs, sys_βs, env_βs, sys_dp, env_dp, sys_ms, env_ms, sys_enlarge, env_enlarge, superblock_H2, OM, comm, rank, Ncpu, engine, correlation, margin, lattice)
+    block_context = _StepBlockContext(Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine, lattice)
+    correction_context = _StepCorrectionContext(superblock_bonds, sys_connS, env_connS, sys_enl, env_enl, x_conn, y_conn, sys_tensor_dict_hold, env_tensor_dict_hold, sys_tensor_dict, env_tensor_dict, sys_ms, env_ms, sys_dp, env_dp, sys_βs, env_βs, sys_enlarge, env_enlarge, engine)
+
+    newblock, newblock_enl, trmat, newtensor_dict = _step_result_buffers(Val(Nc), engine)
+    buffers = _DMRGStepOutputBuffers(
+        newblock,
+        newblock_enl,
+        trmat,
+        newtensor_dict,
+        Float64[],
+        Dict{SUNIrrep{Nc}, Vector{Float64}}[],
+        Float64[],
+    )
+
+    for switch in 1 : (env_calc ? 2 : 1)
+        side = _step_side_context(switch, sys_label, sys_len, env_len, sys_ms, env_ms, sys_βs, env_βs, sys_dp, env_dp, x_conn, y_conn, sys, env, sys_enl, env_enl)
+        Sj = _run_dmrg_step_side!(buffers, switch, side, Ψ0, Sj, blocks, workspace, density_context, measurement_context, block_context, correction_context, Val(Nc))
+    end
+
+    _report_overlap(Ψ0_guess, Ψ0, comm, rank, noisy)
+    return _dmrg_step_result(
+        Val(env_calc),
+        buffers.newblock[1],
+        buffers.newtensor_dict[1],
+        buffers.newblock_enl[1],
+        buffers.truncation_error[1],
+        energy,
+        Ψ0,
+        buffers.trmat[1],
+        buffers.ee[1],
+        buffers.es[1],
+        Sj,
+        buffers.newblock,
+        buffers.newtensor_dict,
+        buffers.newblock_enl,
+        buffers.trmat,
+    )
+end
+
+function _run_dmrg_step_side!(buffers::_DMRGStepOutputBuffers, switch, side::_StepSideContext, Ψ0, Sj, blocks::_DMRGStepBlocks, workspace::_StepWorkspace, density_context::_StepDensityContext, measurement_context::_StepMeasurementContext, block_context::_StepBlockContext, correction_context::_StepCorrectionContext, ::Val{Nc}) where Nc
+    (; sys, env, sys_enl, env_enl) = blocks
+    (; sys_len, env_len) = workspace
+    (; comm, rank, noisy) = density_context
+    (; ms, label) = side
+    βs = side.betas
+
+    balancer::Vector{Int} = _density_matrix_balancer(ms, density_context.Ncpu, rank)
+    MPI.Bcast!(balancer, 0, comm)
+
+    dimβ = dim.(βs)
+    ρs = _reduced_density_matrices(Ψ0, switch, side, dimβ, sys_len, env_len, density_context)
+
+    if rank == 0 && density_context.α != 0.0
+        _apply_density_matrix_correction!(ρs, switch, side, density_context, correction_context)
+    end
+
+    MPI.Barrier(comm)
+
+    ρnew = _balanced_density_matrices(ρs, balancer, side, density_context)
+
+    MPI.Barrier(comm)
+
+    λζtemp, time_DM = _density_eigendecomposition(ρnew, density_context)
+    time2 = MPI.Reduce(time_DM, MPI.MAX, 0, comm)
+
+    if noisy && rank == 0 && switch == 1
+        println(time2, " seconds elapsed in the density matrix diagonalization")
+    end
+
+    MPI.Barrier(comm)
+
+    λ, ζ = _collect_density_eigenpairs(λζtemp, balancer, side, density_context)
+
+    MPI.Barrier(comm)
+
+    ee_value, esi, transformation_matrix, msnew, Hnew, indices = _density_truncation_basis(λ, ζ, side, dimβ, sys_enl, env_enl, density_context, Val(Nc), switch)
+    push!(buffers.ee, ee_value)
+    push!(buffers.trmat, transformation_matrix)
+    push!(buffers.es, esi)
+
+    MPI.Barrier(comm)
+    tensor_dict, Sj = _measure_step_tensor_dict!(measurement_context, switch, label, sys, env, sys_enl, env_enl, Ψ0, transformation_matrix, Sj)
+    MPI.Barrier(comm)
+
+    _push_step_block!(buffers.newblock, buffers.newtensor_dict, buffers.newblock_enl, tensor_dict, side, msnew, Hnew, block_context, Val(Nc))
+
+    if rank == 0
+        push!(buffers.truncation_error, _step_truncation_error(λ, indices, dimβ, buffers.newblock_enl[switch], Val(Nc)))
+        if noisy && switch == 1
+            println("truncation error: ", buffers.truncation_error[switch])
+        end
+    else
+        push!(buffers.truncation_error, 0.0)
+    end
+
+    return Sj
+end
+
 function dmrg_step!(
     SiSj,
     sys_label,
@@ -35,98 +157,13 @@ function dmrg_step!(
     alg = :slow,
     noisy = true,
 ) where {Nc, env_calc}
-    workspace = _prepare_step_workspace(sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl, Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, γ_list, engine, lattice, Val(Nc))
-    (; sys_αs, env_αs, sys_βs, env_βs, sys_ms, env_ms, sys_len, env_len, superblock_bonds, bonds_hold, x_conn, y_conn, sys_dp, env_dp, sys_enlarge, env_enlarge, OM, superblock_H1, superblock_H2, sys_connS, env_connS, sys_tensor_dict_hold, env_tensor_dict_hold) = workspace
-
-    Ψ0 = _initial_step_wavefunction(Ψ0_guess, env_ms, sys_ms, OM, Ncpu, rank, engine)
-    lanczos_context = _StepLanczosContext(target, comm, rank, engine, alg, superblock_H1, bonds_hold, x_conn, y_conn, sys_connS, env_connS, sys_ms, env_ms, sys_βs, env_βs, sys_dp, env_dp, sys_enlarge, env_enlarge, sys_tensor_dict_hold, env_tensor_dict_hold, superblock_H2, OM, sys_len, env_len, Ncpu)
-    E, time_Lanczos = _run_step_lanczos!(Ψ0, lanczos_context)
-    energy = _step_energy(E, time_Lanczos, sys_enl, env_enl, superblock_bonds, comm, rank, noisy, Val(Nc))
-    density_context = _StepDensityContext(comm, rank, Ncpu, engine, α, m, ES_max, noisy)
-    measurement_context = _StepMeasurementContext(SiSj, Ly, x_conn, y_conn, sys_connS, env_connS, sys_len, env_len, sys_tensor_dict, env_tensor_dict, sys_tensor_dict_hold, env_tensor_dict_hold, sys_αs, env_αs, sys_βs, env_βs, sys_dp, env_dp, sys_ms, env_ms, sys_enlarge, env_enlarge, superblock_H2, OM, comm, rank, Ncpu, engine, correlation, margin, lattice)
-    block_context = _StepBlockContext(Ly, widthmax, signfactor, comm, rank, Ncpu, tables, on_the_fly, engine, lattice)
-    correction_context = _StepCorrectionContext(superblock_bonds, sys_connS, env_connS, sys_enl, env_enl, x_conn, y_conn, sys_tensor_dict_hold, env_tensor_dict_hold, sys_tensor_dict, env_tensor_dict, sys_ms, env_ms, sys_dp, env_dp, sys_βs, env_βs, sys_enlarge, env_enlarge, engine)
-
-    newblock, newblock_enl, trmat, newtensor_dict = _step_result_buffers(Val(Nc), engine)
-
-    ee = Float64[]
-    es = Dict{SUNIrrep{Nc}, Vector{Float64}}[]
-    truncation_error = Float64[]
-
-    for switch in 1 : (env_calc ? 2 : 1)
-        side = _step_side_context(switch, sys_label, sys_len, env_len, sys_ms, env_ms, sys_βs, env_βs, sys_dp, env_dp, x_conn, y_conn, sys, env, sys_enl, env_enl)
-        (; len, ms, dp, conn, label, block, block_enl) = side
-        βs = side.betas
-
-        balancer::Vector{Int} = _density_matrix_balancer(ms, density_context.Ncpu, density_context.rank)
-        MPI.Bcast!(balancer, 0, comm)
-
-        dimβ = dim.(βs)
-        ρs = _reduced_density_matrices(Ψ0, switch, side, dimβ, sys_len, env_len, density_context)
-
-        if density_context.rank == 0 && density_context.α != 0.0
-            _apply_density_matrix_correction!(ρs, switch, side, density_context, correction_context)
-        end
-
-        MPI.Barrier(comm)
-
-        ρnew = _balanced_density_matrices(ρs, balancer, side, density_context)
-
-        MPI.Barrier(comm)
-
-        λζtemp, time_DM = _density_eigendecomposition(ρnew, density_context)
-
-        time2 = MPI.Reduce(time_DM, MPI.MAX, 0, comm)
-
-        if noisy && rank == 0 && switch == 1
-            println(time2, " seconds elapsed in the density matrix diagonalization")
-        end
-
-        MPI.Barrier(comm)
-
-        λ, ζ = _collect_density_eigenpairs(λζtemp, balancer, side, density_context)
-
-        MPI.Barrier(comm)
-
-        ee_value, esi, transformation_matrix, msnew, Hnew, indices = _density_truncation_basis(λ, ζ, side, dimβ, sys_enl, env_enl, density_context, Val(Nc), switch)
-        push!(ee, ee_value)
-        push!(trmat, transformation_matrix)
-        push!(es, esi)
-
-        MPI.Barrier(comm)
-        tensor_dict, Sj = _measure_step_tensor_dict!(measurement_context, switch, label, sys, env, sys_enl, env_enl, Ψ0, transformation_matrix, Sj)
-        MPI.Barrier(comm)
-
-        _push_step_block!(newblock, newtensor_dict, newblock_enl, tensor_dict, side, msnew, Hnew, block_context, Val(Nc))
-
-        if rank == 0
-            push!(truncation_error, _step_truncation_error(λ, indices, dimβ, newblock_enl[switch], Val(Nc)))
-            if noisy && switch == 1
-                println("truncation error: ", truncation_error[switch])
-            end
-        else
-            push!(truncation_error, 0.0)
-        end
-    end
-
-    _report_overlap(Ψ0_guess, Ψ0, comm, rank, noisy)
-    return _dmrg_step_result(
-        Val(env_calc),
-        newblock[1],
-        newtensor_dict[1],
-        newblock_enl[1],
-        truncation_error[1],
-        energy,
-        Ψ0,
-        trmat[1],
-        ee[1],
-        es[1],
-        Sj,
-        newblock,
-        newtensor_dict,
-        newblock_enl,
-        trmat,
-    )
+    blocks = _DMRGStepBlocks(sys_label, sys, env, sys_tensor_dict, env_tensor_dict, sys_enl, env_enl)
+    schedule = _DMRGStepSchedule(m, α)
+    settings = _DMRGStepSettings(Ly, widthmax, target, signfactor, tables, on_the_fly, γ_list, alg, lattice)
+    runtime = _DMRGStepRuntime(comm, rank, Ncpu, engine)
+    options = _DMRGStepOptions(Ψ0_guess, ES_max, correlation, margin, Sj, noisy)
+    request = _DMRGStepRequest(blocks, schedule, options, Val(env_calc))
+    return dmrg_step!(SiSj, request, settings, runtime, Val(Nc))
 end
 
 abstract type AbstractDMRGStepResult end

--- a/src/step_types.jl
+++ b/src/step_types.jl
@@ -53,6 +53,69 @@ struct _StepSideContext{MS,B,D,BT,BET}
     block_enl::BET
 end
 
+struct _DMRGStepBlocks{SysT,EnvT,SysTensorT,EnvTensorT,SysEnlT,EnvEnlT}
+    sys_label::Symbol
+    sys::SysT
+    env::EnvT
+    sys_tensor_dict::SysTensorT
+    env_tensor_dict::EnvTensorT
+    sys_enl::SysEnlT
+    env_enl::EnvEnlT
+end
+
+struct _DMRGStepSchedule
+    m::Int
+    α::Float64
+end
+
+struct _DMRGStepSettings{TablesT,OnTheFlyT,GammaT,AlgT,LatticeT}
+    Ly::Int
+    widthmax::Int
+    target::Int
+    signfactor::Float64
+    tables::TablesT
+    on_the_fly::OnTheFlyT
+    γ_list::GammaT
+    alg::AlgT
+    lattice::LatticeT
+end
+
+struct _DMRGStepRuntime{CommT,E}
+    comm::CommT
+    rank::Int
+    Ncpu::Int
+    engine::Type{E}
+end
+
+struct _DMRGStepOptions{GuessT,CorrelationT,SjT}
+    Ψ0_guess::GuessT
+    ES_max::Float64
+    correlation::CorrelationT
+    margin::Int
+    Sj::SjT
+    noisy::Bool
+end
+
+struct _DMRGStepRequest{EnvCalc,BlocksT,ScheduleT,OptionsT}
+    blocks::BlocksT
+    schedule::ScheduleT
+    options::OptionsT
+end
+
+function _DMRGStepRequest(blocks, schedule, options, ::Val{env_calc}) where env_calc
+    _DMRGStepRequest{env_calc,typeof(blocks),typeof(schedule),typeof(options)}(blocks, schedule, options)
+end
+
+struct _DMRGStepOutputBuffers{BlockT,BlockEnlT,TrmatT,TensorT,EET,EST,TrerrT}
+    newblock::BlockT
+    newblock_enl::BlockEnlT
+    trmat::TrmatT
+    newtensor_dict::TensorT
+    ee::EET
+    es::EST
+    truncation_error::TrerrT
+end
+
 struct _StepLanczosContext{CommT,E,A,H1,BondsT,SysConnT,EnvConnT,MST,BetaT,DPT,EnlargeT,SysTensorT,EnvTensorT,H2T,OMT}
     target::Int
     comm::CommT

--- a/test/test_step_helpers.jl
+++ b/test/test_step_helpers.jl
@@ -98,6 +98,36 @@ end
     @test side.block_enl == env_enl
 end
 
+@testset "DMRG step request helpers" begin
+    blocks = SUNDMRG._dmrg_step_blocks(:l, :sys, :env, :sys_tensors, :env_tensors, :sys_enl, :env_enl)
+    @test blocks isa SUNDMRG._DMRGStepBlocks
+    @test blocks.sys_label == :l
+    @test blocks.sys == :sys
+    @test blocks.env_tensor_dict == :env_tensors
+
+    request = @inferred SUNDMRG._dmrg_step_request(
+        blocks,
+        (16, 1e-5),
+        Val(true);
+        Ψ0_guess = :guess,
+        ES_max = 12.0,
+        correlation = Val(:nn),
+        margin = 2,
+        Sj = :sj,
+        noisy = false,
+    )
+    @test request isa SUNDMRG._DMRGStepRequest{true}
+    @test request.blocks === blocks
+    @test request.schedule.m == 16
+    @test request.schedule.α == 1e-5
+    @test request.options.Ψ0_guess == :guess
+    @test request.options.ES_max == 12.0
+    @test request.options.correlation == Val(:nn)
+    @test request.options.margin == 2
+    @test request.options.Sj == :sj
+    @test request.options.noisy == false
+end
+
 @testset "Density matrix balancer helper" begin
     @test SUNDMRG._density_matrix_balancer(Int[], 1, 0) == Int[]
     @test SUNDMRG._density_matrix_balancer([10, 20, 30], 1, 0) == [0, 0, 0]


### PR DESCRIPTION
## Summary

- Bump SUNDMRG.jl to v1.5.0 and add an initial CHANGELOG entry.
- Refactor internal DMRG step calls around structured request/settings/runtime objects while preserving the existing compatibility wrapper.
- Add the initial Documenter.jl documentation scaffold with DMRG overview and SU(Nc) representation-theory pages.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `julia --project=docs docs/make.jl`

## Notes

- `gh auth status` reports the local GitHub CLI token is invalid, so this PR was opened through the GitHub app connector after pushing the branch.