### PR TITLE
[codex] Refactor representation theory helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.5.3
+
+### Changed
+
+- Bumped package version to v1.5.3.
+- Split SU(N) representation-theory helpers into a `RepresentationTheory` submodule.
+- Added SU(2) 3ν, 6ν, and 9ν coefficient regression tests.
+- Added SU(3)-SU(5) coefficient regression tests against the bundled JLD2 tables.
+- Allowed table-generation utility scripts to accept `Nc` and `widthmax` command-line arguments.
+- Made coefficient-table MPI initialization/finalization cooperate with caller-managed MPI sessions.
+
 ## v1.5.2
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.5.2"
+version = "1.5.3"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ using SUNDMRG
 
 makedocs(;
     sitename = "SUNDMRG.jl",
-    modules = [SUNDMRG],
+    modules = [SUNDMRG, SUNDMRG.RepresentationTheory],
     checkdocs = :none,
     format = Documenter.HTML(; prettyurls = get(ENV, "CI", "false") == "true"),
     pages = [

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -37,6 +37,23 @@ init_DMRG!
 finalize_DMRG!
 ```
 
+## Representation Theory
+
+```@docs
+SUNDMRG.RepresentationTheory
+SUNDMRG.RepresentationTheory.RepresentationTable
+SUNDMRG.RepresentationTheory.irrep
+SUNDMRG.RepresentationTheory.irreplist
+SUNDMRG.RepresentationTheory.trivialirrep
+SUNDMRG.RepresentationTheory.fundamentalirrep
+SUNDMRG.RepresentationTheory.adjointirrep
+SUNDMRG.RepresentationTheory.outer_multiplicity
+SUNDMRG.RepresentationTheory.OM_matrix
+SUNDMRG.RepresentationTheory.wigner3ν
+SUNDMRG.RepresentationTheory.wigner6ν
+SUNDMRG.RepresentationTheory.wigner9ν
+```
+
 ## Coefficient Tables
 
 ```@docs

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -113,3 +113,11 @@ make_table(3, 13)
 
 `make_table3nu` and `make_table4` produce the partial table files.
 `make_table` combines them into the `tables` file consumed by `run_DMRG`.
+
+The scripts in `utils/` provide the same entry points from the command line:
+
+```bash
+julia --project=. utils/make_table3nu.jl 3 13
+julia --project=. utils/make_table4.jl 3 13
+julia --project=. utils/make_table.jl 3 13
+```

--- a/src/SUNDMRG.jl
+++ b/src/SUNDMRG.jl
@@ -3,21 +3,33 @@ module SUNDMRG
 using MPI
 using LinearAlgebra
 using SUNRepresentations
-using RationalRoots
-using WignerSymbols
-using JLD2
 using CUDA
 using MAGMA
 
-# using Threads
-using ThreadsX
-using Permutations
-using OMEinsum
+include("representation_theory.jl")
+using .RepresentationTheory
+using .RepresentationTheory: SparseVector2,
+    sparsevec2,
+    spzeros2,
+    multiplicity,
+    SYTdiagram,
+    bf,
+    subdiagram,
+    P!,
+    Papply!,
+    Papply2!,
+    representatives,
+    antisymmetrize,
+    SDC,
+    _3ν,
+    _6ν,
+    _6νrev,
+    _9ν,
+    table_9ν
 
-export DMRGOutput, run_DMRG, init_DMRG!, finalize_DMRG!, make_table, make_table3nu, make_table4, HeisenbergModel, SU, SquareLattice, HoneycombLattice, CPUEngine, GPUEngine
+export DMRGOutput, run_DMRG, init_DMRG!, finalize_DMRG!, make_table, make_table3nu, make_table4, HeisenbergModel, SU, SquareLattice, HoneycombLattice, CPUEngine, GPUEngine, RepresentationTheory
 
 include("types.jl")
-include("suncalc.jl")
 include("lanczos.jl")
 include("engine_utils.jl")
 include("storage.jl")
@@ -37,13 +49,5 @@ include("finite_support.jl")
 include("finite_sweep.jl")
 include("finite_phases.jl")
 include("finite.jl")
-
-include("sparsevec2.jl")
-include("sytx.jl")
-include("subduction.jl")
-include("tablecalc.jl")
-include("table4.jl")
-include("table3nu.jl")
-include("table.jl")
 
 end

--- a/src/representation_theory.jl
+++ b/src/representation_theory.jl
@@ -1,0 +1,79 @@
+module RepresentationTheory
+
+using LinearAlgebra
+using MPI
+using SUNRepresentations
+using RationalRoots
+using WignerSymbols
+using JLD2
+using ThreadsX
+using Permutations
+using OMEinsum
+
+export RepresentationTable,
+    irrep,
+    irreplist,
+    outer_multiplicity,
+    OM_matrix,
+    trivialirrep,
+    adjointirrep,
+    fundamentalirrep,
+    wigner3ν,
+    wigner6ν,
+    racahU,
+    wigner9ν,
+    wigner9j,
+    wigner6νrev,
+    make_table,
+    make_table3nu,
+    make_table4
+
+"""
+    RepresentationTheory
+
+Submodule containing SU(N) representation helpers and coefficient-table
+generation routines used by SUNDMRG.
+"""
+RepresentationTheory
+
+"""
+    RepresentationTable
+
+Tuple type used for the combined SU(N) coefficient tables consumed by DMRG
+runs.
+"""
+const RepresentationTable = NTuple{6, Any}
+
+function _init_table_mpi!(manage_mpi::Bool)
+    if !manage_mpi
+        (MPI.Initialized() && !MPI.Finalized()) || throw(ArgumentError("MPI must be initialized when manage_mpi = false"))
+        return false
+    end
+    if MPI.Finalized()
+        throw(ArgumentError("MPI has already been finalized and cannot be initialized again in this process"))
+    end
+    if !MPI.Initialized()
+        MPI.Init(; threadlevel = MPI.THREAD_FUNNELED)
+        return true
+    end
+    return false
+end
+
+function _finalize_table_mpi!(did_initialize::Bool)
+    if did_initialize && MPI.Initialized() && !MPI.Finalized()
+        MPI.Finalize()
+        return true
+    end
+    return false
+end
+
+include("sparsevec2.jl")
+include("suncalc.jl")
+include("sytx.jl")
+include("subduction.jl")
+include("tablecalc.jl")
+include("table4.jl")
+include("table3nu.jl")
+include("table.jl")
+
+end

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -1,3 +1,5 @@
+using JLD2
+
 abstract type AbstractInternalStorage end
 
 const _HostTrmat = Vector{Matrix{Float64}}

--- a/src/table3nu.jl
+++ b/src/table3nu.jl
@@ -1,14 +1,18 @@
 """
-    make_table3nu(Nc, widthmax)
+    make_table3nu(Nc, widthmax; manage_mpi = true)
 
 Generate the SU(Nc) three-symbol coefficient table used by DMRG runs with
 `Nc > 2`.
 
 This is an MPI workload intended for a cluster or other multi-process
 environment. It writes `table3nuhalf_SU\$(Nc)_\$(widthmax).jld2`.
+
+When `manage_mpi = true`, the function initializes MPI if needed and finalizes
+MPI only if it performed the initialization. Pass `manage_mpi = false` when MPI
+is managed by the caller.
 """
-function make_table3nu(Nc, widthmax)
-    MPI.Init()
+function make_table3nu(Nc, widthmax; manage_mpi = true)
+    did_initialize_mpi = _init_table_mpi!(manage_mpi)
 
     comm = MPI.COMM_WORLD
     Ncpu = MPI.Comm_size(comm)
@@ -183,5 +187,5 @@ function make_table3nu(Nc, widthmax)
         println("All finished!")
     end
 
-    MPI.Finalize()
+    _finalize_table_mpi!(did_initialize_mpi)
 end

--- a/src/table4.jl
+++ b/src/table4.jl
@@ -1,14 +1,18 @@
 """
-    make_table4(Nc, widthmax)
+    make_table4(Nc, widthmax; manage_mpi = true)
 
 Generate the SU(Nc) four-index coefficient table used by DMRG runs with
 `Nc > 2`.
 
 This is an MPI workload intended for a cluster or other multi-process
 environment. It writes `table4half_SU\$(Nc)_\$(widthmax).jld2`.
+
+When `manage_mpi = true`, the function initializes MPI if needed and finalizes
+MPI only if it performed the initialization. Pass `manage_mpi = false` when MPI
+is managed by the caller.
 """
-function make_table4(Nc, widthmax)
-    MPI.Init()
+function make_table4(Nc, widthmax; manage_mpi = true)
+    did_initialize_mpi = _init_table_mpi!(manage_mpi)
 
     comm = MPI.COMM_WORLD
     size = MPI.Comm_size(comm)
@@ -148,5 +152,5 @@ function make_table4(Nc, widthmax)
         println("All finished!")
     end
 
-    MPI.Finalize()
+    _finalize_table_mpi!(did_initialize_mpi)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using SUNDMRG
     include("test_storage.jl")
     include("test_finite_helpers.jl")
     include("test_tables_small.jl")
+    include("test_tables_ground_truth.jl")
     include("test_step_helpers.jl")
     include("test_lanczos_helpers.jl")
     include("test_tools_onthefly.jl")

--- a/test/test_tables_ground_truth.jl
+++ b/test/test_tables_ground_truth.jl
@@ -1,0 +1,65 @@
+using JLD2
+using SUNRepresentations: SUNIrrep
+
+_ground_truth_irrep(::Val{Nc}, weight) where Nc = SUNIrrep{Nc}(Tuple(weight))
+_ground_truth_key(::Val{Nc}, weights) where Nc = Tuple(_ground_truth_irrep(Val(Nc), weight) for weight in weights)
+
+function _ground_truth_tables(Nc, widthmax)
+    JLD2.load(joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$(widthmax).jld2"), "tables")
+end
+
+function _ground_truth_table5_reference(::Val{Nc}, key) where Nc
+    funda = SUNDMRG.fundamentalirrep(Val(Nc))
+    αj, βl, αi, γ, βk = key
+    SUNDMRG._6ν(αj, funda, βl, αi, γ, βk)[1, :, 1, :] .* SUNDMRG._3ν(αi, funda, βk)[1, 1]
+end
+
+function _ground_truth_table4_reference(::Val{Nc}, key) where Nc
+    adjoint = SUNDMRG.adjointirrep(Val(Nc))
+    trivial = SUNDMRG.trivialirrep(Val(Nc))
+    α1, β1, γ, α2, β2 = key
+    SUNDMRG._9ν(α1, β1, γ, adjoint, adjoint, trivial, α2, β2, γ)[:, :, :, :, 1, 1]
+end
+
+@testset "SU(3)-SU(5) JLD2 table ground truth" begin
+    cases = (
+        (
+            Nc = 3,
+            widthmax = 13,
+            three = ((1, 0, 0), (1, 1, 0), (0, 0, 0)),
+            six = ((1, 0, 0), (1, 1, 0), (1, 0, 0), (0, 0, 0), (1, 1, 0)),
+            nine = ((1, 0, 0), (1, 0, 0), (1, 1, 0), (1, 0, 0), (1, 0, 0)),
+        ),
+        (
+            Nc = 4,
+            widthmax = 9,
+            three = ((1, 0, 0, 0), (1, 0, 0, 0), (1, 1, 0, 0)),
+            six = ((1, 1, 0, 0), (1, 1, 1, 0), (1, 0, 0, 0), (0, 0, 0, 0), (1, 1, 0, 0)),
+            nine = ((1, 0, 0, 0), (1, 0, 0, 0), (1, 1, 0, 0), (1, 0, 0, 0), (1, 0, 0, 0)),
+        ),
+        (
+            Nc = 5,
+            widthmax = 3,
+            three = ((1, 0, 0, 0, 0), (1, 0, 0, 0, 0), (1, 1, 0, 0, 0)),
+            six = ((1, 0, 0, 0, 0), (1, 1, 0, 0, 0), (1, 1, 1, 0, 0), (0, 0, 0, 0, 0), (1, 1, 1, 1, 0)),
+            nine = ((1, 0, 0, 0, 0), (1, 0, 0, 0, 0), (1, 1, 0, 0, 0), (1, 0, 0, 0, 0), (1, 0, 0, 0, 0)),
+        ),
+    )
+
+    for case in cases
+        tables = _ground_truth_tables(case.Nc, case.widthmax)
+        table4, table5, table6 = tables[4], tables[5], tables[6]
+
+        three_key = _ground_truth_key(Val(case.Nc), case.three)
+        @test haskey(table6, three_key)
+        @test SUNDMRG._3ν(three_key...) ≈ table6[three_key]
+
+        six_key = _ground_truth_key(Val(case.Nc), case.six)
+        @test haskey(table5, six_key)
+        @test _ground_truth_table5_reference(Val(case.Nc), six_key) ≈ table5[six_key]
+
+        nine_key = _ground_truth_key(Val(case.Nc), case.nine)
+        @test haskey(table4, nine_key)
+        @test _ground_truth_table4_reference(Val(case.Nc), nine_key) ≈ table4[nine_key]
+    end
+end

--- a/test/test_tables_small.jl
+++ b/test/test_tables_small.jl
@@ -17,3 +17,46 @@
     # On-the-fly table helper matches direct 3ν exchange matrix.
     @test SUNDMRG.on_the_fly_calc6((funda, funda, adj)) == SUNDMRG.wigner3ν(funda, funda, adj)
 end
+
+@testset "SU(2) 3ν/6ν/9ν coefficient values" begin
+    trivial = SUNDMRG.trivialirrep(Val(2))
+    funda = SUNDMRG.fundamentalirrep(Val(2))
+    adj = SUNDMRG.adjointirrep(Val(2))
+
+    c3 = SUNDMRG._3ν(funda, funda, adj)
+    w3 = SUNDMRG.wigner3ν(funda, funda, adj)
+    @test c3 ≈ w3
+    @test only(c3) ≈ 1.0
+
+    c6 = SUNDMRG._6ν(funda, funda, adj, funda, funda, adj)
+    w6 = SUNDMRG.wigner6ν(funda, funda, adj, funda, funda, adj)
+    @test c6 ≈ w6
+    @test only(c6) ≈ 0.5
+
+    c6r = SUNDMRG._6νrev(funda, funda, adj, funda, funda, adj)
+    @test c6r ≈ permutedims(c6, (3, 4, 1, 2))
+
+    nineν_cases = (
+        (trivial, funda, funda, adj, trivial, adj, adj, funda, funda),
+        (funda, funda, trivial, adj, adj, trivial, funda, funda, trivial),
+        (funda, funda, adj, funda, funda, adj, adj, adj, trivial),
+    )
+    expected = (-1.0, 1 / sqrt(3), -0.5)
+    for (case, value) in zip(nineν_cases, expected)
+        c9 = SUNDMRG._9ν(case...)
+        w9 = SUNDMRG.wigner9ν(case...)
+        @test c9 ≈ w9
+        @test only(c9) ≈ value
+    end
+end
+
+@testset "RepresentationTheory submodule coefficient access" begin
+    RT = SUNDMRG.RepresentationTheory
+    trivial = RT.trivialirrep(Val(2))
+    funda = RT.fundamentalirrep(Val(2))
+    adj = RT.adjointirrep(Val(2))
+
+    @test RT._3ν(funda, funda, adj) ≈ SUNDMRG._3ν(funda, funda, adj)
+    @test RT._6ν(funda, funda, adj, funda, funda, adj) ≈ SUNDMRG._6ν(funda, funda, adj, funda, funda, adj)
+    @test RT._9ν(trivial, funda, funda, adj, trivial, adj, adj, funda, funda) ≈ SUNDMRG._9ν(trivial, funda, funda, adj, trivial, adj, adj, funda, funda)
+end

--- a/utils/make_table.jl
+++ b/utils/make_table.jl
@@ -1,9 +1,19 @@
 using SUNDMRG
 
 function main()
-    Nc = 4
-    widthmax = 9
+    Nc, widthmax = parse_args()
     make_table(Nc, widthmax)
 end
 
-main()
+function parse_args(args = ARGS)
+    if length(args) == 0
+        return 4, 9
+    elseif length(args) == 2
+        return parse(Int, args[1]), parse(Int, args[2])
+    end
+    throw(ArgumentError("usage: julia --project=. utils/make_table.jl [Nc widthmax]"))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/utils/make_table3nu.jl
+++ b/utils/make_table3nu.jl
@@ -1,9 +1,19 @@
 using SUNDMRG
 
 function main()
-    Nc = 4
-    widthmax = 9
+    Nc, widthmax = parse_args()
     make_table3nu(Nc, widthmax)
 end
 
-main()
+function parse_args(args = ARGS)
+    if length(args) == 0
+        return 4, 9
+    elseif length(args) == 2
+        return parse(Int, args[1]), parse(Int, args[2])
+    end
+    throw(ArgumentError("usage: julia --project=. utils/make_table3nu.jl [Nc widthmax]"))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/utils/make_table4.jl
+++ b/utils/make_table4.jl
@@ -1,9 +1,19 @@
 using SUNDMRG
 
 function main()
-    Nc = 4
-    widthmax = 9
+    Nc, widthmax = parse_args()
     make_table4(Nc, widthmax)
 end
 
-main()
+function parse_args(args = ARGS)
+    if length(args) == 0
+        return 4, 9
+    elseif length(args) == 2
+        return parse(Int, args[1]), parse(Int, args[2])
+    end
+    throw(ArgumentError("usage: julia --project=. utils/make_table4.jl [Nc widthmax]"))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end


### PR DESCRIPTION
## Summary

- Split SU(N) representation-theory and coefficient-table helpers into a `RepresentationTheory` submodule while preserving existing top-level compatibility.
- Add SU(2) coefficient regression tests and SU(3)-SU(5 ground-truth checks against bundled JLD2 tables.
- Improve table-generation utilities with `Nc widthmax` CLI arguments and make MPI table generation cooperate with caller-managed MPI sessions.
- Update docs and changelog for the new module and utility usage.

## Validation

- `julia --project=. test/runtests.jl` (`282 / 282` pass)
- `julia --project=docs docs/make.jl`