### PR TITLE
[codex] Refactor docs and bump version to v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.5.4
+
+### Changed
+
+- Bumped package version to v1.5.4.
+- Added a SUNDMRG-specific algorithm documentation page.
+- Reorganized the documentation navigation around getting started, runtime options, coefficient tables, algorithm notes, SU(Nc) symmetry, and API reference.
+- Split coefficient-table and runtime-option details out of the usage guide.
+- Reduced README duplication by keeping it focused on the shortest runnable example and documentation entry points.
+
 ## v1.5.3
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.5.3"
+version = "1.5.4"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -23,45 +23,27 @@ After that, you can do:
 
 ## Usage
 
-If you want to run the simulation of the SU(2) Heisenberg model on the 4x4 square lattice
-with a default setting, please use the following.
-```julia
-rank, dmrg = run_DMRG(SU(2)HeisenbergModel(), SquareLattice(4, 4), 100, [100, 200, 400, 800], 1600, CPUEngine)
-```
-`dmrg` is returned only when `rank == 0` when you are using the MPI parallelization.
+Run a small SU(2) Heisenberg calculation on a 4x4 square lattice with:
 
-By default, `run_DMRG` initializes and finalizes MPI for a single run. If you want to
-run multiple simulations in the same Julia session, manage MPI outside the calls:
 ```julia
-init_DMRG!()
-try
-    run_DMRG(SU(2)HeisenbergModel(), SquareLattice(4, 4), 100, [100], 100, CPUEngine; manage_mpi = false)
-    run_DMRG(SU(2)HeisenbergModel(), SquareLattice(4, 4), 100, [100], 100, CPUEngine; manage_mpi = false)
-finally
-    finalize_DMRG!()
-end
+using SUNDMRG
+
+rank, dmrg = run_DMRG(
+    SU(2)HeisenbergModel(),
+    SquareLattice(4, 4),
+    100,
+    [100, 200, 400, 800],
+    1600,
+    CPUEngine,
+)
 ```
 
-For a more detailed configuration, please look at the examples directory.
+`dmrg` is returned only on MPI rank 0. SU(2) coefficients are evaluated on the fly;
+SU(N) runs with `N > 2` usually use precomputed coefficient tables.
 
-Please be careful that the expectation value of the bond operator is returned
-in the format of P<sub>ij</sub> - 1 / N<sub>c</sub> for SU(N<sub>c</sub>) for the accuracy.
-
-## SU(2)
-
-SUNDMRG.jl supports an on-the-fly calculation of SU(2) symmetry coefficients (Wigner symbols).
-The bond Hamiltonian is **S**<sub>i</sub>・**S**<sub>j</sub> in the SU(2) case, not P<sub>ij</sub> = 2 **S**<sub>i</sub>・**S**<sub>j</sub> + 1 / 2.
-SiSj is also evaluated by **S**<sub>i</sub>・**S**<sub>j</sub>, not P<sub>ij</sub> - 1 / 2.
-
-## Density matrix mixing
-
-The density matrix mixing (sometimes called a noise term) is a technique to have a better convergence
-in DMRG. It perturbs the density matrix a little, avoiding being stuck in some local minima.
-The small perturbation is specified in the second term of the tuple for each sweep as follows.
-```julia
-rank, dmrg = run_DMRG(SU(3)HeisenbergModel(), SquareLattice(6, 6), (100, 1e-5), [(100, 1e-5), (200, 1e-6), (400, 1e-7), (800, 1e-8)], (1600, 0.0), CPUEngine; widthmax = widthmax, tables = tables)
-```
-The value has to become zero or a negligibly small value in the last few sweeps.
+See the documentation for [usage](docs/src/usage.md), [examples](docs/src/examples.md),
+and the [algorithm overview](docs/src/algorithm.md). Runnable scripts are available
+in the `examples/` directory.
 
 ## Dependency
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,12 +10,21 @@ makedocs(;
     format = Documenter.HTML(; prettyurls = get(ENV, "CI", "false") == "true"),
     pages = [
         "Home" => "index.md",
-        "DMRG Overview" => "dmrg_overview.md",
-        "Usage" => "usage.md",
-        "Examples" => "examples.md",
-        "SU(Nc) Representation Theory" => "representation_theory.md",
-        "Examples of SU(Nc) Representations" => "su_n_examples.md",
-        "Representation Labels in SUNDMRG.jl" => "representation_notation.md",
+        "Getting Started" => [
+            "Usage" => "usage.md",
+            "Runtime Options" => "runtime_options.md",
+            "Examples" => "examples.md",
+        ],
+        "Coefficient Tables" => "coefficient_tables.md",
+        "Algorithm" => [
+            "DMRG Overview" => "dmrg_overview.md",
+            "SUNDMRG Algorithm" => "algorithm.md",
+        ],
+        "SU(Nc) Symmetry" => [
+            "Representation Theory" => "representation_theory.md",
+            "Representation Examples" => "su_n_examples.md",
+            "Representation Labels" => "representation_notation.md",
+        ],
         "API Reference" => "api.md",
     ],
 )

--- a/docs/src/algorithm.md
+++ b/docs/src/algorithm.md
@@ -1,0 +1,153 @@
+# SUNDMRG Algorithm
+
+This page explains how SUNDMRG.jl organizes a finite-system DMRG run.
+For a general introduction to DMRG, start with [DMRG Overview](dmrg_overview.md).
+This page focuses on the package-specific flow, data structures, and symmetry handling.
+
+## Overall Run Flow
+
+The public entry point is [`run_DMRG`](@ref).
+After validating the model, lattice, schedule, and keyword arguments, the run builds
+an MPI/runtime context and then executes four main phases:
+
+1. Initialize empty left and right blocks.
+2. Warm up the system until the transverse width is reached.
+3. Grow the finite system to the full lattice size.
+4. Sweep through the fixed-size system until convergence, then perform measurements.
+
+Only MPI rank 0 returns a [`DMRGOutput`](@ref). Other ranks participate in the
+distributed linear algebra and return `nothing` for the result object.
+
+## Symmetry-Adapted Blocks
+
+SUNDMRG stores each block in SU(Nc) symmetry sectors rather than as one dense Hilbert
+space. A block records:
+
+- its length and internal lattice bonds;
+- the SU(Nc) irreducible representations present in the block;
+- the number of retained multiplets in each representation;
+- scalar operators such as the block Hamiltonian;
+- tensor operators used to build interactions and measurements.
+
+When a block is enlarged by one site, each current representation is tensored with
+the fundamental representation. The resulting candidate representations become the
+sector labels of the enlarged block, subject to the representation cutoff used for
+precomputed tables.
+
+For SU(2), the required symmetry coefficients can be evaluated on the fly. For
+SU(Nc) with `Nc > 2`, production runs usually use precomputed coefficient tables.
+
+## One DMRG Step
+
+A single DMRG step combines an enlarged system block and an enlarged environment block
+into a superblock problem. The step performs the following work:
+
+1. Determine the active lattice bonds crossing the current cut.
+2. Build the pieces of the effective Hamiltonian in symmetry-sector form.
+3. Solve the target superblock state with Lanczos.
+4. Build reduced density matrices from the optimized wavefunction.
+5. Optionally add density-matrix mixing.
+6. Diagonalize the density matrices and choose the retained multiplets.
+7. Project the block Hamiltonian and tensor operators into the truncated basis.
+8. Return the new block, transformation matrix, energy, truncation error, and
+   entanglement data.
+
+The effective Hamiltonian is not materialized as one large dense matrix. Instead,
+Lanczos receives a function that applies the Hamiltonian to the structured
+wavefunction.
+
+## Wavefunction Layout
+
+The superblock wavefunction is stored as a matrix indexed by environment and system
+irreducible representations. Each entry is a vector over outer-multiplicity channels,
+and each channel contains a dense matrix of retained multiplet amplitudes.
+
+This layout lets the algorithm apply symmetry selection rules directly. The linear
+algebra helpers in the implementation operate on this nested matrix-of-vectors
+structure, while MPI reductions combine distributed contributions to inner products,
+norms, and Hamiltonian applications.
+
+## Lanczos Solve
+
+The Lanczos solver targets the requested eigenstate of the effective Hamiltonian.
+For each Hamiltonian application:
+
+- block Hamiltonians act within their own SU(Nc) sectors;
+- inter-block interaction terms use tensor operators on the system and environment;
+- SU(Nc) recoupling coefficients connect allowed sector transitions;
+- MPI distributes the sector and bond contributions across ranks.
+
+The `alg = :slow` mode reconstructs the target Ritz vector by replaying the Lanczos
+recurrence. The `alg = :fast` mode caches Lanczos vectors on the host and uses them
+to speed up reconstruction, which can be useful for larger runs.
+
+## Density Matrix Truncation
+
+After Lanczos, the optimized wavefunction defines reduced density matrices for the
+side being enlarged. These density matrices are block diagonal in SU(Nc) sectors.
+
+SUNDMRG diagonalizes the sector density matrices, ranks the eigenvalues globally,
+and keeps the requested number of SU(Nc) multiplets. Because each retained multiplet
+represents all states in its irrep, the code also reports the equivalent number of
+ordinary states when verbose output is enabled.
+
+The discarded density-matrix weight is recorded as the truncation error. The same
+eigenvalues are used to compute the entanglement entropy and, when requested, the
+entanglement spectrum.
+
+## Density Matrix Mixing
+
+Each schedule entry can be either `m` or `(m, alpha)`.
+The second form enables density-matrix mixing, sometimes called a noise term. Early
+sweeps can use a small nonzero `alpha` to reduce the chance of getting trapped in a
+poor local minimum. Final sweeps should use zero, or a negligibly small value, so
+the reported state is not biased by the mixing term.
+
+## Warmup, Growth, And Sweeps
+
+The warmup phase starts from empty blocks and grows them until the transverse width
+`Ly` is reached.
+
+The growth phase then extends the system to the full lattice size `Lx * Ly`. During
+growth, the previous optimized wavefunction is transformed into a prediction for the
+next step whenever possible.
+
+The sweep phase fixes the system size and moves the active cut left and right through
+the lattice. At each cut, the environment block is loaded from saved block data,
+enlarged, and used to improve the current system block. Sweeps continue until the
+relative changes in energy and entanglement entropy pass the configured tolerances.
+
+## Measurements
+
+After convergence, SUNDMRG performs a measurement sweep when correlations were
+requested. The main correlation modes are:
+
+- `:none`: no correlation measurement;
+- `:nn`: nearest-neighbor bond correlations;
+- `:chain`: chain-style correlations using the configured margin.
+
+For SU(Nc), bond expectations are returned in the `P_ij - 1 / N_c` convention.
+For SU(2), the Hamiltonian and `SiSj` values use
+``\mathbf{S}_i \cdot \mathbf{S}_j``.
+
+## Storage And Backends
+
+Intermediate block data can be kept in memory or written to temporary JLD2 files
+with `fileio = true`. File-backed storage is useful for larger sweeps because
+environment blocks and tensor operators can be reconstructed from saved data.
+
+The CPU backend stores dense arrays as `Matrix{Float64}`. The GPU backend stores
+dense working arrays on CUDA devices and uses MAGMA for symmetric eigenvalue
+problems, while file storage converts data back to host arrays.
+
+## Coefficient Tables
+
+The SU(Nc) tensor recoupling data is central to the implementation. SU(2) runs can
+compute the required Wigner coefficients as needed. For `Nc > 2`, the table builders
+generate coefficient dictionaries ahead of time:
+
+- [`make_table3nu`](@ref) generates the three-symbol table;
+- [`make_table4`](@ref) generates the four-index interaction table;
+- [`make_table`](@ref) combines those files into the table tuple consumed by DMRG.
+
+The example scripts load bundled tables from the repository's `jld2/` directory.

--- a/docs/src/coefficient_tables.md
+++ b/docs/src/coefficient_tables.md
@@ -1,0 +1,103 @@
+# Coefficient Tables
+
+SUNDMRG uses SU(Nc) recoupling coefficients when it builds symmetry-adapted block
+operators and superblock interactions. The way those coefficients are supplied
+depends on `Nc`.
+
+## SU(2)
+
+SU(2) runs do not need an external coefficient table. The package evaluates the
+required Wigner-symbol data on the fly.
+
+```julia
+rank, dmrg = run_DMRG(
+    SU(2)HeisenbergModel(),
+    SquareLattice(4, 4),
+    100,
+    [100, 200, 400, 800],
+    1600,
+    CPUEngine,
+)
+```
+
+The default `widthmax = 0` and `tables = nothing` are appropriate for this case.
+
+## SU(Nc) With `Nc > 2`
+
+For larger symmetry groups, pass both a representation cutoff and a precomputed
+table tuple:
+
+```julia
+using SUNDMRG
+using JLD2
+
+Nc = 3
+widthmax = 13
+@load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
+
+rank, dmrg = run_DMRG(
+    SU(Nc)HeisenbergModel(),
+    HoneycombLattice(6, 6, :ZC),
+    100,
+    [100, 200, 400, 800],
+    1600,
+    CPUEngine;
+    widthmax = widthmax,
+    tables = tables,
+)
+```
+
+The `widthmax` keyword controls which irreducible representations are retained in
+the table-backed representation list. The `tables` keyword supplies the coefficient
+dictionaries consumed by the DMRG kernels.
+
+Bundled example tables are available in the repository's `jld2/` directory:
+
+- `table_SU3_13.jld2`
+- `table_SU4_9.jld2`
+- `table_SU5_3.jld2`
+
+## Generating Tables
+
+For `Nc > 2`, table generation is a separate workload. It is MPI-oriented and is
+usually run on a cluster or other multi-process environment.
+
+The generation flow is:
+
+1. [`make_table3nu`](@ref) writes `table3nuhalf_SU$(Nc)_$(widthmax).jld2`.
+2. [`make_table4`](@ref) writes `table4half_SU$(Nc)_$(widthmax).jld2`.
+3. [`make_table`](@ref) reads those partial files and writes
+   `table_SU$(Nc)_$(widthmax).jld2`.
+
+From Julia:
+
+```julia
+using SUNDMRG
+
+make_table3nu(3, 13)
+make_table4(3, 13)
+make_table(3, 13)
+```
+
+From the checked-in utility scripts:
+
+```bash
+julia --project=. utils/make_table3nu.jl 3 13
+julia --project=. utils/make_table4.jl 3 13
+julia --project=. utils/make_table.jl 3 13
+```
+
+When table generation is part of a larger MPI-managed Julia session, pass
+`manage_mpi = false` to the table builders after initializing MPI externally.
+
+## Table Contents
+
+The combined table loaded by DMRG is a tuple of coefficient dictionaries. Internal
+DMRG code uses these tables to update tensor operators, build inter-block
+interaction terms, predict wavefunctions across sweeps, and reverse system and
+environment orderings.
+
+Most users only need to load the table object and pass it to `run_DMRG`. The
+representation-theory details behind the coefficients are described in
+[SU(Nc) Representation Theory](representation_theory.md) and
+[SUNDMRG Algorithm](algorithm.md).

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -103,21 +103,5 @@ for the result object.
 For ``N_c > 2``, the table files are generated separately.
 The table builders are MPI-oriented workloads and are usually run on a cluster.
 
-```julia
-using SUNDMRG
-
-make_table3nu(3, 13)
-make_table4(3, 13)
-make_table(3, 13)
-```
-
-`make_table3nu` and `make_table4` produce the partial table files.
-`make_table` combines them into the `tables` file consumed by `run_DMRG`.
-
-The scripts in `utils/` provide the same entry points from the command line:
-
-```bash
-julia --project=. utils/make_table3nu.jl 3 13
-julia --project=. utils/make_table4.jl 3 13
-julia --project=. utils/make_table.jl 3 13
-```
+See [Coefficient Tables](coefficient_tables.md) for the generation flow and the
+`utils/` commands.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,21 +2,31 @@
 
 SUNDMRG.jl is a DMRG implementation with full SU(N) symmetry.
 
-This documentation starts with the basic DMRG workflow, then covers package usage,
-example scripts, the representation-theoretic background used by the package,
-and the public API reference.
+This documentation is organized around three common reading paths:
+running calculations, understanding the algorithm, and working with the
+SU(Nc) representation data used internally by the package.
 
 ```@contents
-Pages = ["dmrg_overview.md", "usage.md", "examples.md", "representation_theory.md", "su_n_examples.md", "representation_notation.md", "api.md"]
+Pages = ["usage.md", "runtime_options.md", "examples.md", "coefficient_tables.md", "dmrg_overview.md", "algorithm.md", "representation_theory.md", "su_n_examples.md", "representation_notation.md", "api.md"]
 Depth = 2
 ```
 
 ## Reading Path
 
-Start with [DMRG Overview](dmrg_overview.md) for the general algorithmic ideas.
-Use [Usage](usage.md) for the first runnable calls and common options.
-The [Examples](examples.md) page explains the scripts in the repository's `examples/` directory.
-Then read [SU(Nc) Representation Theory](representation_theory.md) for the symmetry notation used in SU(Nc)-adapted calculations.
-Continue to [Examples of SU(Nc) Representations](su_n_examples.md) for concrete labels and small tensor-product decompositions.
-The short [Representation Labels in SUNDMRG.jl](representation_notation.md) note records the row-length convention used when labels appear in package-facing contexts.
-Use [API Reference](api.md) when you need signatures and return fields.
+If you want to run a calculation, start with [Usage](usage.md), then continue to
+[Runtime Options](runtime_options.md) for MPI, GPU, file-backed storage, and
+measurement controls. Use [Examples](examples.md) for the checked-in scripts.
+
+If you want to understand the numerical method, read [DMRG Overview](dmrg_overview.md)
+first, then [SUNDMRG Algorithm](algorithm.md) for the package-specific warmup,
+growth, sweep, truncation, and measurement flow.
+
+If you are working with coefficient tables, read
+[Coefficient Tables](coefficient_tables.md). For the representation labels behind
+those tables, read [SU(Nc) Representation Theory](representation_theory.md),
+continue to [Examples of SU(Nc) Representations](su_n_examples.md), and keep
+[Representation Labels in SUNDMRG.jl](representation_notation.md) nearby for the
+row-length convention used in package-facing labels.
+
+Use [API Reference](api.md) when you need signatures, return fields, and exported
+entry points.

--- a/docs/src/runtime_options.md
+++ b/docs/src/runtime_options.md
@@ -1,0 +1,137 @@
+# Runtime Options
+
+This page collects runtime controls that are useful once the basic
+[`run_DMRG`](@ref) workflow is working: MPI lifecycle management, CPU/GPU
+backends, and temporary file-backed storage.
+
+## MPI Lifecycle
+
+By default, `run_DMRG` initializes MPI before a run and finalizes MPI afterward.
+This is convenient for one calculation per Julia process:
+
+```julia
+rank, dmrg = run_DMRG(
+    SU(2)HeisenbergModel(),
+    SquareLattice(4, 4),
+    100,
+    [100],
+    100,
+    CPUEngine,
+)
+```
+
+For multiple calculations in one Julia session, manage MPI outside the individual
+calls:
+
+```julia
+using SUNDMRG
+
+init_DMRG!()
+try
+    run_DMRG(
+        SU(2)HeisenbergModel(),
+        SquareLattice(4, 4),
+        100,
+        [100],
+        100,
+        CPUEngine;
+        manage_mpi = false,
+    )
+
+    run_DMRG(
+        SU(2)HeisenbergModel(),
+        SquareLattice(6, 4),
+        100,
+        [100],
+        100,
+        CPUEngine;
+        manage_mpi = false,
+    )
+finally
+    finalize_DMRG!()
+end
+```
+
+Use [`init_DMRG!`](@ref) and [`finalize_DMRG!`](@ref) as a pair. When
+`manage_mpi = false`, MPI must already be initialized.
+
+## CPU And GPU Engines
+
+The final positional argument to `run_DMRG` selects the dense-array backend.
+
+Use [`CPUEngine`](@ref) for CPU execution:
+
+```julia
+rank, dmrg = run_DMRG(
+    SU(2)HeisenbergModel(),
+    SquareLattice(4, 4),
+    100,
+    [100, 200],
+    400,
+    CPUEngine,
+)
+```
+
+Use [`GPUEngine`](@ref) for CUDA-backed execution:
+
+```julia
+rank, dmrg = run_DMRG(
+    SU(2)HeisenbergModel(),
+    SquareLattice(4, 4),
+    100,
+    [100, 200],
+    400,
+    GPUEngine,
+)
+```
+
+GPU runs require CUDA and MAGMA to be configured before starting the calculation.
+For MPI GPU runs, the implementation expects the number of MPI ranks to be no
+larger than the number of available CUDA devices.
+
+## File-Backed Storage
+
+By default, intermediate blocks, transformation matrices, and tensor data are kept
+in memory. For larger runs, use `fileio = true` to store intermediate data in
+temporary JLD2 files:
+
+```julia
+rank, dmrg = run_DMRG(
+    SU(3)HeisenbergModel(),
+    HoneycombLattice(6, 6, :ZC),
+    100,
+    [100, 200, 400],
+    800,
+    CPUEngine;
+    widthmax = widthmax,
+    tables = tables,
+    fileio = true,
+    scratch = "/path/to/scratch",
+)
+```
+
+The `scratch` keyword selects the parent directory for temporary storage. The
+temporary directory is cleaned up at the end of the run on rank 0.
+
+File-backed storage is especially useful for table-backed SU(Nc) runs where
+environment blocks and tensor operators are reconstructed during sweeps.
+
+## Lanczos Mode
+
+The `alg` keyword controls the Lanczos vector reconstruction mode:
+
+- `alg = :slow`: reconstruct by replaying the Lanczos recurrence.
+- `alg = :fast`: cache Lanczos vectors and reuse them during reconstruction.
+
+The example scripts for larger SU(Nc) calculations use `alg = :fast`.
+
+## Correlation Measurements
+
+The `correlation` keyword controls whether a measurement sweep records two-site
+correlations:
+
+- `correlation = :none`: no correlation measurements.
+- `correlation = :nn`: nearest-neighbor correlations.
+- `correlation = :chain`: chain-style correlations with the configured `margin`.
+
+Rank 0 receives the measured values in the `SiSj` field of [`DMRGOutput`](@ref).

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -2,8 +2,7 @@
 
 This page shows the main user-facing workflow for finite-system DMRG runs.
 The examples use small dimensions for clarity; production calculations usually require
-larger bond dimensions, multiple MPI ranks, and, for SU(Nc) with ``N_c > 2``,
-precomputed coefficient tables.
+larger bond dimensions, multiple MPI ranks, and backend-specific runtime options.
 
 ## Installation
 
@@ -58,51 +57,18 @@ m_cooldown = (1600, 0.0)
 Density-matrix mixing can help avoid local minima early in a calculation.
 Use zero, or a negligibly small value, near the final sweeps.
 
+For more detail on how this schedule is used during warmup, growth, sweeps, and
+measurements, see [SUNDMRG Algorithm](algorithm.md).
+
 ## SU(Nc) Runs With Tables
 
-For ``N_c > 2``, pass a `widthmax` and precomputed coefficient tables.
-The repository examples load these from `jld2/table_SU$(Nc)_$(widthmax).jld2`.
+SU(2) calculations evaluate their symmetry coefficients on the fly. For
+``N_c > 2``, pass a `widthmax` and a precomputed coefficient table with the
+`tables` keyword.
 
-```julia
-using SUNDMRG
-using JLD2
-
-Nc = 3
-widthmax = 13
-@load joinpath(@__DIR__, "..", "jld2", "table_SU$(Nc)_$widthmax.jld2") tables
-
-rank, dmrg = run_DMRG(
-    SU(Nc)HeisenbergModel(),
-    HoneycombLattice(6, 6, :ZC),
-    (100, 1e-5),
-    [(100, 1e-5), (200, 1e-6), (400, 1e-7), (800, 0.0)],
-    (1600, 0.0),
-    CPUEngine;
-    widthmax = widthmax,
-    tables = tables,
-    fileio = true,
-    correlation = :nn,
-    margin = 5,
-    alg = :fast,
-)
-```
-
-## MPI Lifecycle
-
-By default, `run_DMRG` initializes and finalizes MPI for one run.
-If you want multiple runs in the same Julia process, manage MPI explicitly.
-
-```julia
-using SUNDMRG
-
-init_DMRG!()
-try
-    run_DMRG(SU(2)HeisenbergModel(), SquareLattice(4, 4), 100, [100], 100, CPUEngine; manage_mpi = false)
-    run_DMRG(SU(2)HeisenbergModel(), SquareLattice(6, 4), 100, [100], 100, CPUEngine; manage_mpi = false)
-finally
-    finalize_DMRG!()
-end
-```
+See [Coefficient Tables](coefficient_tables.md) for table loading and table
+generation. The repository examples load bundled tables from the `jld2/`
+directory.
 
 ## Common Keywords
 
@@ -116,6 +82,9 @@ end
 - `alg = :slow`: Lanczos mode; examples for larger runs use `:fast`.
 - `verbose = true`: print progress on rank 0.
 - `manage_mpi = true`: let `run_DMRG` manage MPI for a single call.
+
+See [Runtime Options](runtime_options.md) for MPI lifecycle management, GPU runs,
+file-backed storage, Lanczos modes, and correlation measurement options.
 
 ## Output
 


### PR DESCRIPTION
## Summary

- Bump the package version to v1.5.4 and add a corresponding changelog entry.
- Reorganize the documentation navigation into getting started, runtime options, coefficient tables, algorithm notes, SU(Nc) symmetry, and API reference sections.
- Add dedicated pages for the SUNDMRG algorithm, coefficient tables, and runtime options.
- Slim down README and usage/examples pages by moving detailed material into the new focused docs pages.

## Validation

- `julia --project=docs docs/make.jl`

The docs build completed successfully locally. Documenter skipped deployment because the build was not running in CI.