### PR TITLE
[codex] Expand validation and representation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.5.5
+
+### Changed
+
+- Bumped package version to v1.5.5.
+- Accepted integer density-matrix mixing values in DMRG schedules.
+- Added early validation for common `run_DMRG` keyword arguments.
+
+### Tests
+
+- Expanded characterization coverage for API input normalization, MPI lifecycle handling, internal storage, and step helper boundary cases.
+- Added small `run_DMRG` regressions for fast Lanczos reconstruction and chain correlation measurement.
+- Added itemized unit coverage for `RepresentationTheory` internal helpers.
+
 ## v1.5.4
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.5.4"
+version = "1.5.5"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/src/api.jl
+++ b/src/api.jl
@@ -20,15 +20,29 @@ return `nothing` for the output.
 """
 function run_DMRG end
 
-_dmrg_schedule(m::Int) = (m, 0.0)
-_dmrg_schedule(m::Tuple{Int, Float64}) = m
+function _dmrg_schedule(m::Integer)
+    _dmrg_schedule(m, 0.0)
+end
+
+function _dmrg_schedule(m::Tuple{<:Integer, <:Real})
+    _dmrg_schedule(m[1], m[2])
+end
+
+function _dmrg_schedule(m::Integer, α::Real)
+    m > 0 || throw(ArgumentError("DMRG schedule bond dimension m must be positive"))
+    α = Float64(α)
+    isfinite(α) || throw(ArgumentError("DMRG schedule density-matrix mixing α must be finite"))
+    α >= 0.0 || throw(ArgumentError("DMRG schedule density-matrix mixing α must be nonnegative"))
+    return (Int(m), α)
+end
+
 _dmrg_schedule_list(ms::AbstractVector) = Tuple{Int, Float64}[_dmrg_schedule(m) for m in ms]
 
-function run_DMRG(model::HeisenbergModelSU{Nc}, lat::SquareLattice, m_warmup::Union{Int, Tuple{Int, Float64}}, m_sweep_list::AbstractVector, m_cooldown::Union{Int, Tuple{Int, Float64}}, engine::Type{<:Engine}; kwargs...) where Nc
+function run_DMRG(model::HeisenbergModelSU{Nc}, lat::SquareLattice, m_warmup::Union{Integer, Tuple{<:Integer, <:Real}}, m_sweep_list::AbstractVector, m_cooldown::Union{Integer, Tuple{<:Integer, <:Real}}, engine::Type{<:Engine}; kwargs...) where Nc
     _run_DMRG(model, :square, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
 end
 
-function run_DMRG(model::HeisenbergModelSU{Nc}, lat::HoneycombLattice, m_warmup::Union{Int, Tuple{Int, Float64}}, m_sweep_list::AbstractVector, m_cooldown::Union{Int, Tuple{Int, Float64}}, engine::Type{<:Engine}; kwargs...) where Nc
+function run_DMRG(model::HeisenbergModelSU{Nc}, lat::HoneycombLattice, m_warmup::Union{Integer, Tuple{<:Integer, <:Real}}, m_sweep_list::AbstractVector, m_cooldown::Union{Integer, Tuple{<:Integer, <:Real}}, engine::Type{<:Engine}; kwargs...) where Nc
     if lat.BC == :ZC
         return _run_DMRG(model, :honeycombZC, lat.Lx, lat.Ly, _dmrg_schedule(m_warmup), _dmrg_schedule_list(m_sweep_list), _dmrg_schedule(m_cooldown), engine; kwargs...)
     end

--- a/src/finite.jl
+++ b/src/finite.jl
@@ -1,4 +1,5 @@
 function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sweep_list, m_cooldown, engine; target = 0, widthmax = 0, tables = nothing, fileio = false, scratch = ".", ES_max = 20.0, tol_energy = 1e-5, tol_EE = 1e-3, correlation = :none, margin = 0, alg = :slow, verbose = true, manage_mpi = true) where Nc
+    _validate_run_DMRG_options(Val(Nc), target, widthmax, tables, fileio, tol_energy, tol_EE, margin, verbose, manage_mpi)
     correlation ∈ (:none, :nn, :chain) || throw(ArgumentError("correlation must be :none, :nn, or :chain"))
     alg ∈ (:slow, :fast) || throw(ArgumentError("alg must be :slow or :fast"))
 
@@ -36,6 +37,35 @@ function _run_DMRG(model::HeisenbergModelSU{Nc}, lattice, Lx, Ly, m_warmup, m_sw
             finalize_DMRG!()
         end
     end
+end
+
+function _validate_run_DMRG_options(::Val{Nc}, target, widthmax, tables, fileio, tol_energy, tol_EE, margin, verbose, manage_mpi) where Nc
+    target isa Integer || throw(ArgumentError("target must be an integer"))
+    target >= 0 || throw(ArgumentError("target must be nonnegative"))
+    widthmax isa Integer || throw(ArgumentError("widthmax must be an integer"))
+    widthmax >= 0 || throw(ArgumentError("widthmax must be nonnegative"))
+    margin isa Integer || throw(ArgumentError("margin must be an integer"))
+    margin >= 0 || throw(ArgumentError("margin must be nonnegative"))
+    fileio isa Bool || throw(ArgumentError("fileio must be true or false"))
+    verbose isa Bool || throw(ArgumentError("verbose must be true or false"))
+    manage_mpi isa Bool || throw(ArgumentError("manage_mpi must be true or false"))
+
+    _positive_finite_option(tol_energy, "tol_energy")
+    _positive_finite_option(tol_EE, "tol_EE")
+
+    if Nc > 2
+        widthmax > 0 || throw(ArgumentError("widthmax must be positive for SU(N > 2)"))
+        tables === nothing && throw(ArgumentError("tables must be provided for SU(N > 2)"))
+    end
+
+    return nothing
+end
+
+function _positive_finite_option(value, name)
+    value isa Real || throw(ArgumentError("$name must be real"))
+    value = Float64(value)
+    isfinite(value) && value > 0.0 || throw(ArgumentError("$name must be positive and finite"))
+    return value
 end
 
 function _run_DMRG_impl(config::_FiniteRunConfig, runtime::_FiniteRuntime, runtime_finalized, ::Val{Nc}) where Nc

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using SUNDMRG
     include("test_finite_helpers.jl")
     include("test_tables_small.jl")
     include("test_tables_ground_truth.jl")
+    include("test_representation_theory_internal.jl")
     include("test_step_helpers.jl")
     include("test_lanczos_helpers.jl")
     include("test_tools_onthefly.jl")

--- a/test/test_init.jl
+++ b/test/test_init.jl
@@ -21,3 +21,37 @@
     @test SUNDMRG.graphic(left, right; sys_label = :r) == "---**=="
     @test_throws ArgumentError SUNDMRG.graphic(left, right; sys_label = :x)
 end
+
+@testset "DMRG schedule normalization" begin
+    @test SUNDMRG._dmrg_schedule(12) == (12, 0.0)
+    @test SUNDMRG._dmrg_schedule((12, 0.25)) == (12, 0.25)
+
+    schedules = SUNDMRG._dmrg_schedule_list(Any[4, (8, 1e-3), 16])
+    @test schedules == [(4, 0.0), (8, 1e-3), (16, 0.0)]
+    @test schedules isa Vector{Tuple{Int, Float64}}
+
+    @test SUNDMRG._dmrg_schedule((12, 0)) == (12, 0.0)
+    @test SUNDMRG._dmrg_schedule_list([(4, 0), (8, 1)]) == [(4, 0.0), (8, 1.0)]
+
+    @test_throws ArgumentError SUNDMRG._dmrg_schedule(0)
+    @test_throws ArgumentError SUNDMRG._dmrg_schedule((-1, 0.0))
+    @test_throws ArgumentError SUNDMRG._dmrg_schedule((12, -1e-3))
+    @test_throws ArgumentError SUNDMRG._dmrg_schedule((12, Inf))
+    @test_throws ArgumentError SUNDMRG._dmrg_schedule((12, NaN))
+end
+
+@testset "Runtime validation helpers" begin
+    on_the_fly, mirror, γ_type, γ_list, N, signfactor = SUNDMRG._init_runtime_and_engine(SUNDMRG.CPUEngine, :square, 4, 4, 2, 0, 1)
+
+    @test on_the_fly == Val(true)
+    @test mirror
+    @test γ_type == typeof(SUNDMRG.trivialirrep(Val(2)))
+    @test length(γ_list) == 2
+    @test N == 16
+    @test signfactor == -1.0
+
+    @test_throws ArgumentError SUNDMRG._init_runtime_and_engine(SUNDMRG.CPUEngine, :square, 4, 4, 1, 0, 1)
+    @test_throws ArgumentError SUNDMRG._init_runtime_and_engine(SUNDMRG.CPUEngine, :triangular, 4, 4, 2, 0, 1)
+    @test_throws ArgumentError SUNDMRG._init_runtime_and_engine(SUNDMRG.CPUEngine, :square, 4, 4, 3, 0, 1)
+    @test_throws ArgumentError SUNDMRG._init_runtime_and_engine(SUNDMRG.CPUEngine, :square, 4, 3, 4, 0, 1)
+end

--- a/test/test_representation_theory_internal.jl
+++ b/test/test_representation_theory_internal.jl
@@ -1,0 +1,124 @@
+using LinearAlgebra: diag
+using SUNRepresentations: directproduct, dim, weight
+
+@testset "RepresentationTheory submodule access" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    @test RT.RepresentationTable == NTuple{6, Any}
+    @test RT.irrep(3, 3) == SUNDMRG.irrep(3, 3)
+    @test RT.trivialirrep(Val(3)) == SUNDMRG.trivialirrep(Val(3))
+    @test RT.fundamentalirrep(Val(3)) == SUNDMRG.fundamentalirrep(Val(3))
+    @test RT.adjointirrep(Val(3)) == SUNDMRG.adjointirrep(Val(3))
+end
+
+@testset "RepresentationTheory irrep enumeration" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    irreps = RT.irreplist(3, 2)
+    @test weight.(irreps) == [
+        (0, 0, 0),
+        (1, 0, 0),
+        (1, 1, 0),
+        (2, 0, 0),
+        (2, 1, 0),
+        (2, 2, 0),
+    ]
+    @test dim.(irreps) == [1, 3, 3, 6, 8, 6]
+    @test all(weight(irrep)[1] <= 2 for irrep in irreps)
+
+    trivial = RT.trivialirrep(Val(3))
+    funda = RT.fundamentalirrep(Val(3))
+    adjoint = RT.adjointirrep(Val(3))
+    @test RT.outer_multiplicity(funda, funda, adjoint) == 0
+    @test RT.outer_multiplicity(funda, funda, irreps[4]) == 1
+    @test RT.outer_multiplicity(funda, trivial, funda) == 1
+    @test RT.OM_matrix(irreps[1:3], trivial) == RT.OM_matrix(irreps[1:3], irreps[1:3], trivial)
+    @test haskey(directproduct(funda, trivial), funda)
+end
+
+@testset "Young diagram and SYT helpers" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    @test RT.multiplicity(Int[]) == 1
+    @test RT.multiplicity([1]) == 1
+    @test RT.multiplicity([2, 1]) == 2
+    @test RT.multiplicity([3, 2]) == 5
+
+    V, E, D = RT.SYTdiagram([2, 1])
+    @test V == [[[1]], [[1, 1], [2]], [[2, 1]]]
+    @test E == [[[1, 2]], [[1], [1]]]
+    @test D == [[[3, 2]], [[2], [3]]]
+
+    B, F = RT.bf(3, V, E, Int)
+    @test B == [[2], [1, 1], [1]]
+    @test F == [[[0, 1]], [[0], [0]]]
+    @test RT.subdiagram([[1]], [2, 1], 1, E, D, B, F, Int) == (1, 2, 1)
+
+    reps = RT.representatives([Int[]], [[1]], [1])
+    @test reps == [(1,)]
+end
+
+@testset "Subduction coefficients" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    onevec = RT.sparsevec2(Int128[1], [1.0], Int128(1))
+    for key in (
+        ((0, 0), (1, 0), (1, 0)),
+        ((1, 0), (0, 0), (1, 0)),
+        ((1, 0), (1, 0), (2, 0)),
+        ((1, 0), (1, 0), (1, 1)),
+    )
+        coeffs = RT.SDC(key..., onevec, onevec)
+        @test length(coeffs) == 1
+        @test only(coeffs).n == 1
+        @test only(coeffs).nzind == Int128[1]
+        @test only(coeffs).nzval ≈ [1.0]
+    end
+
+    V, E, D = RT.SYTdiagram([2])
+    B, F = RT.bf(2, V, E, Int)
+    basis, dim_subspace, initj = RT._SDC((1,), (1,), (2,), E, D, B, F, Int)
+    @test dim_subspace == 1
+    @test initj == 1
+    @test length(basis) == 1
+    @test only(basis).nzind == [1]
+    @test only(basis).nzval ≈ [1.0]
+end
+
+@testset "Wigner and Racah wrappers" begin
+    RT = SUNDMRG.RepresentationTheory
+    trivial = RT.trivialirrep(Val(2))
+    funda = RT.fundamentalirrep(Val(2))
+    adjoint = RT.adjointirrep(Val(2))
+
+    @test RT.racahU(funda, funda, funda, funda, adjoint, adjoint) ≈
+          RT.wigner6ν(funda, funda, adjoint, funda, funda, adjoint)
+
+    w6 = RT.wigner6ν(funda, funda, adjoint, funda, funda, adjoint)
+    @test RT.wigner6νrev(funda, funda, adjoint, funda, funda, adjoint) ≈ permutedims(w6, (3, 4, 1, 2))
+    @test RT.wigner9j(1 // 2, 1 // 2, 0, 1 // 2, 1 // 2, 0, 0, 0, 0) ≈ 0.5
+
+    impossible = RT.wigner6ν(trivial, trivial, funda, trivial, trivial, trivial)
+    @test size(impossible) == (1, 1, 0, 0)
+end
+
+@testset "Subduction linear algebra helpers" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    @test RT.findabsmax([0.0, -3.0, 2.0]) == (3.0, 2)
+    @test_throws ArgumentError RT.findabsmax(Float64[])
+
+    Q, R = RT.qrpos!([1.0 0.0; 0.0 -2.0])
+    @test Q * R ≈ [1.0 0.0; 0.0 -2.0]
+    @test diag(R) == [1.0, 2.0]
+end
+
+@testset "Representation table MPI lifecycle helpers" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    SUNDMRG.MPI.Initialized() || SUNDMRG.MPI.Init(; threadlevel = SUNDMRG.MPI.THREAD_FUNNELED)
+
+    @test RT._init_table_mpi!(false) == false
+    @test RT._init_table_mpi!(true) == false
+    @test RT._finalize_table_mpi!(false) == false
+end

--- a/test/test_run_dmrg.jl
+++ b/test/test_run_dmrg.jl
@@ -1,9 +1,23 @@
 @testset "run_DMRG regression" begin
     @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; correlation = :bad)
     @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; alg = :bad)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; target = -1)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; widthmax = -1)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; margin = -1)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; tol_energy = 0.0)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; tol_EE = NaN)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; fileio = :yes)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; verbose = :yes)
+    @test_throws ArgumentError run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; manage_mpi = :yes)
+    @test_throws ArgumentError run_DMRG(SU(3)HeisenbergModel(), SquareLattice(4, 3), 20, [20], 20, CPUEngine; widthmax = 0, tables = ())
+    @test_throws ArgumentError run_DMRG(SU(3)HeisenbergModel(), SquareLattice(4, 3), 20, [20], 20, CPUEngine; widthmax = 3, tables = nothing)
     @test_throws ArgumentError SUNDMRG._init_runtime_and_engine(CPUEngine, :square, 3, 4, 2, 0, 1)
 
-    init_DMRG!()
+    did_init = init_DMRG!()
+    @test did_init isa Bool
+    @test SUNDMRG.MPI.Initialized()
+    @test !SUNDMRG.MPI.Finalized()
+    @test init_DMRG!() == false
     try
         rank, dmrg = run_DMRG(SU(2)HeisenbergModel(), SquareLattice(4, 4), 100, [100, 200, 400, 800], 1600, CPUEngine; verbose = false, manage_mpi = false)
 
@@ -26,6 +40,15 @@
             end
         end
 
+        rank_fast, dmrg_fast = run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; alg = :fast, verbose = false, manage_mpi = false)
+
+        @test rank_fast == 0
+        if rank_fast == 0
+            @test length(dmrg_fast.energies) == 4
+            @test last(dmrg_fast.energies) ≈ -3.2320508075688767 atol = 1e-12
+            @test isempty(dmrg_fast.SiSj)
+        end
+
         rank_nn, dmrg_nn = run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; correlation = :nn, verbose = false, manage_mpi = false)
 
         @test rank_nn == 0
@@ -34,7 +57,18 @@
             @test last(dmrg_nn.energies) ≈ -3.2320508075688767 atol = 1e-12
             @test sort(collect(keys(dmrg_nn.SiSj))) == [(1, 2), (1, 4), (2, 3), (3, 4)]
         end
+
+        rank_chain, dmrg_chain = run_DMRG(SU(2)HeisenbergModel(), SquareLattice(2, 2), 20, [20], 20, CPUEngine; correlation = :chain, margin = 0, verbose = false, manage_mpi = false)
+
+        @test rank_chain == 0
+        if rank_chain == 0
+            @test length(dmrg_chain.energies) == 4
+            @test last(dmrg_chain.energies) ≈ -3.2320508075688767 atol = 1e-12
+            @test sort(collect(keys(dmrg_chain.SiSj))) == [(1, 4)]
+            @test dmrg_chain.SiSj[(1, 4)] ≈ -0.25 atol = 1e-12
+        end
     finally
-        finalize_DMRG!()
+        @test finalize_DMRG!()
+        @test finalize_DMRG!() == false
     end
 end

--- a/test/test_step_helpers.jl
+++ b/test/test_step_helpers.jl
@@ -41,6 +41,20 @@ end
 
     @test SUNDMRG._rank_held_bonds([(1, 1), (2, 2), (2, 1)], 2, 0) == [(1, 1), (0, 0)]
     @test SUNDMRG._rank_held_bonds([(1, 1), (2, 2), (2, 1)], 2, 1) == [(2, 2), (2, 1)]
+
+    bonds, x_conn, y_conn = SUNDMRG._step_bonds(3, 3, 2, :honeycombZC)
+    @test bonds == [(2, 2), (2, 1)]
+    @test x_conn == 2
+    @test y_conn == 2
+
+    for rank in 0 : 3
+        @test SUNDMRG._rank_held_bonds(Tuple{Int, Int}[], 4, rank) == Tuple{Int, Int}[]
+    end
+
+    @test SUNDMRG._rank_held_bonds([(1, 1)], 4, 0) == [(0, 0)]
+    @test SUNDMRG._rank_held_bonds([(1, 1)], 4, 1) == [(0, 0)]
+    @test SUNDMRG._rank_held_bonds([(1, 1)], 4, 2) == [(0, 0)]
+    @test SUNDMRG._rank_held_bonds([(1, 1)], 4, 3) == [(1, 1)]
 end
 
 @testset "DMRG step allocation helpers" begin

--- a/test/test_storage.jl
+++ b/test/test_storage.jl
@@ -15,8 +15,14 @@
 
     @test SUNDMRG.load_block(storage, :l, 2) == block
     @test SUNDMRG.load_trmat(storage, :l, 2) == trmat
+    @test SUNDMRG.has_tensor(storage, :l, 2, 1)
     @test SUNDMRG.load_tensor(storage, :l, 2, 1) == tensor
+    @test !SUNDMRG.has_tensor(storage, :l, 2, 1)
     @test SUNDMRG.load_tensor(storage, :l, 2, 1) === nothing
+
+    SUNDMRG.save_tensor(storage, :l, 2, 1, tensor)
+    @test SUNDMRG.take_tensor!(storage, :l, 2, 1) == tensor
+    @test !SUNDMRG.has_tensor(storage, :l, 2, 1)
 
     @test SUNDMRG.init_internal_storage(false, ".", block_table, trmat_table, tensor_table, 0) isa SUNDMRG.MemoryInternalStorage
 
@@ -31,8 +37,14 @@
 
         @test SUNDMRG.load_block(disk_storage, :r, 3) == block
         @test SUNDMRG.load_trmat(disk_storage, :r, 3) == trmat
+        @test SUNDMRG.has_tensor(disk_storage, :r, 3, 2)
         @test SUNDMRG.load_tensor(disk_storage, :r, 3, 2) == tensor
+        @test !SUNDMRG.has_tensor(disk_storage, :r, 3, 2)
         @test SUNDMRG.load_tensor(disk_storage, :r, 3, 2) === nothing
+
+        SUNDMRG.save_tensor(disk_storage, :r, 3, 2, tensor)
+        @test SUNDMRG.take_tensor!(disk_storage, :r, 3, 2) == tensor
+        @test !SUNDMRG.has_tensor(disk_storage, :r, 3, 2)
 
         SUNDMRG.cleanup_storage!(disk_storage)
         @test !isdir(joinpath(scratch, "temp$dirid"))
@@ -42,5 +54,10 @@
         @test isdir(joinpath(scratch, "temp$(initialized.dirid)"))
         SUNDMRG.cleanup_storage!(initialized)
         @test !isdir(joinpath(scratch, "temp$(initialized.dirid)"))
+
+        worker_storage = SUNDMRG.init_internal_storage(true, scratch, block_table, trmat_table, tensor_table, 1)
+        @test worker_storage isa SUNDMRG.JLD2InternalStorage
+        @test worker_storage.dirid == "00000"
+        @test !isdir(joinpath(scratch, "temp00000"))
     end
 end


### PR DESCRIPTION
## Summary

- Bump the package version to v1.5.5 and document the changes.
- Accept integer density-matrix mixing values in DMRG schedules and add early validation for common `run_DMRG` keyword arguments.
- Expand unit coverage for API input normalization, MPI lifecycle handling, internal storage, step helper boundaries, small `run_DMRG` regressions, and `RepresentationTheory` internals.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test()'` passed with `Pass 406 / Total 406`.
