### PR TITLE
Document Wigner/Racah coefficient tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.5.6
+
+### Changed
+
+- Bumped package version to v1.5.6.
+- Added Wigner/Racah coefficient documentation connecting 3ν, 6ν, and 9ν definitions to implementation functions and DMRG table slots.
+- Linked the Wigner/Racah coefficient guide from the documentation navigation, index, and coefficient-table page.
+
+### Tests
+
+- Added definition-based representation-theory tests for Young row-length enumeration, hook-length multiplicities, Weyl dimensions, tensor-product dimension preservation, and SDC orthonormality.
+- Added SDC recoupling tests for `_3ν`, `_6ν`, and `_9ν`, including the formal `P_{23}` exchange in the 9ν construction.
+
 ## v1.5.5
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNDMRG"
 uuid = "f5f04b14-1ee9-4d01-a958-b95a245b82cc"
-version = "1.5.5"
+version = "1.5.6"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,7 @@ makedocs(;
             "Representation Theory" => "representation_theory.md",
             "Representation Examples" => "su_n_examples.md",
             "Representation Labels" => "representation_notation.md",
+            "Wigner/Racah Coefficients" => "wigner_racah.md",
         ],
         "API Reference" => "api.md",
     ],

--- a/docs/src/coefficient_tables.md
+++ b/docs/src/coefficient_tables.md
@@ -100,4 +100,6 @@ environment orderings.
 Most users only need to load the table object and pass it to `run_DMRG`. The
 representation-theory details behind the coefficients are described in
 [SU(Nc) Representation Theory](representation_theory.md) and
-[SUNDMRG Algorithm](algorithm.md).
+[SUNDMRG Algorithm](algorithm.md). For a direct map from Wigner/Racah symbols to
+implementation functions and table slots, see
+[Wigner/Racah Coefficients](wigner_racah.md).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ running calculations, understanding the algorithm, and working with the
 SU(Nc) representation data used internally by the package.
 
 ```@contents
-Pages = ["usage.md", "runtime_options.md", "examples.md", "coefficient_tables.md", "dmrg_overview.md", "algorithm.md", "representation_theory.md", "su_n_examples.md", "representation_notation.md", "api.md"]
+Pages = ["usage.md", "runtime_options.md", "examples.md", "coefficient_tables.md", "dmrg_overview.md", "algorithm.md", "representation_theory.md", "su_n_examples.md", "representation_notation.md", "wigner_racah.md", "api.md"]
 Depth = 2
 ```
 
@@ -26,7 +26,8 @@ If you are working with coefficient tables, read
 those tables, read [SU(Nc) Representation Theory](representation_theory.md),
 continue to [Examples of SU(Nc) Representations](su_n_examples.md), and keep
 [Representation Labels in SUNDMRG.jl](representation_notation.md) nearby for the
-row-length convention used in package-facing labels.
+row-length convention used in package-facing labels. For the recoupling
+coefficients themselves, use [Wigner/Racah Coefficients](wigner_racah.md).
 
 Use [API Reference](api.md) when you need signatures, return fields, and exported
 entry points.

--- a/docs/src/wigner_racah.md
+++ b/docs/src/wigner_racah.md
@@ -1,0 +1,185 @@
+# Wigner/Racah Coefficients
+
+This page connects the recoupling notation used by SUNDMRG.jl with the
+implementation functions and the coefficient tables consumed by DMRG runs.
+
+SUNDMRG labels SU(Nc) irreducible representations by Young row lengths, stored as
+`SUNIrrep{Nc}` values. In the formulas below, ``\nu_i`` denotes such an
+irreducible representation, and ``\tau`` labels an outer-multiplicity channel.
+The symbols ``f``, ``a``, and ``1`` denote the fundamental, adjoint, and trivial
+representations, respectively.
+
+## Recoupling Symbols
+
+The low-level construction starts from subduction coefficients. If
+``C_{\tau}(\nu_1,\nu_2;\nu)`` denotes the embedding of the ``\tau``-th copy of
+``\nu`` inside ``\nu_1 \otimes \nu_2``, then the Wigner/Racah symbols used here
+are overlaps between two different coupling schemes.
+
+The underscored routines `_3ν`, `_6ν`, and `_9ν` are the general SDC-based
+builders used during table generation. The `wigner3ν`, `wigner6ν`, and
+`wigner9ν` wrappers provide the SU(2) on-the-fly path used by DMRG runs with
+`Nc == 2`; runs with `Nc > 2` consume precomputed table entries instead.
+
+### 3ν
+
+The 3ν symbol exchanges two coupled representations:
+
+```math
+[3\nu(\nu_1,\nu_2;\nu)]_{\tau',\tau}
+=
+\left\langle
+  C_{\tau'}(\nu_2,\nu_1;\nu),
+  P_{12} C_{\tau}(\nu_1,\nu_2;\nu)
+\right\rangle .
+```
+
+Implementation:
+
+- `SUNDMRG.RepresentationTheory._3ν(ν1, ν2, ν)`
+- `SUNDMRG.RepresentationTheory.wigner3ν(ν1, ν2, ν)`
+
+The returned array has indices `W[τ′, τ]`. This is an exchange matrix on the
+outer-multiplicity space. It is not a Wigner 3j symbol and not a Clebsch-Gordan
+coefficient.
+
+### 6ν / Racah U
+
+The 6ν symbol changes the parenthesization of three representations:
+
+```math
+\left[
+\begin{matrix}
+\nu_1 & \nu_2 & \nu_{12} \\
+\nu_3 & \nu     & \nu_{23}
+\end{matrix}
+\right]_{\tau_{23},\tau',\tau_{12},\tau}
+=
+\left\langle
+  [\nu_1 \otimes (\nu_2 \otimes \nu_3)_{\nu_{23}}]_{\nu,\tau'},
+  [(\nu_1 \otimes \nu_2)_{\nu_{12}} \otimes \nu_3]_{\nu,\tau}
+\right\rangle .
+```
+
+Implementation:
+
+- `SUNDMRG.RepresentationTheory._6ν(ν1, ν2, ν12, ν3, ν, ν23)`
+- `SUNDMRG.RepresentationTheory.wigner6ν(ν1, ν2, ν12, ν3, ν, ν23)`
+- `SUNDMRG.RepresentationTheory.racahU(ν1, ν2, ν, ν3, ν12, ν23)`
+
+The returned array has indices `W[τ23, τ′, τ12, τ]`. For SU(2),
+`wigner6ν` is implemented as a Racah-U coefficient. If the SU(2) row-length
+label is ``\mu = 2j``, then the implementation evaluates a dimension factor
+times the usual Racah ``W(j_1,j_2,j,j_3,j_{12},j_{23})``.
+
+### 9ν
+
+The 9ν symbol changes the pairing of four representations:
+
+```math
+\left[
+\begin{matrix}
+\nu_1  & \nu_2  & \nu_{12} \\
+\nu_3  & \nu_4  & \nu_{34} \\
+\nu_{13} & \nu_{24} & \nu
+\end{matrix}
+\right]_{\tau_{13},\tau_{24},\tau',\tau_{12},\tau_{34},\tau}
+=
+\left\langle
+  [(\nu_1 \otimes \nu_3)_{\nu_{13}}
+   \otimes
+   (\nu_2 \otimes \nu_4)_{\nu_{24}}]_{\nu,\tau'},
+  P_{23}
+  [(\nu_1 \otimes \nu_2)_{\nu_{12}}
+   \otimes
+   (\nu_3 \otimes \nu_4)_{\nu_{34}}]_{\nu,\tau}
+\right\rangle .
+```
+
+Here ``P_{23}`` is the formal exchange of the second and third tensor factors,
+turning the ordering ``\nu_1 \otimes \nu_2 \otimes \nu_3 \otimes \nu_4`` into
+``\nu_1 \otimes \nu_3 \otimes \nu_2 \otimes \nu_4`` before the overlap is taken.
+In the implementation this is the `perm = true` branch of the final
+`SDC(ν12, ν34, ν, ...; f1 = N1, f4 = N4)` call.
+
+Implementation:
+
+- `SUNDMRG.RepresentationTheory._9ν(ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν)`
+- `SUNDMRG.RepresentationTheory.wigner9ν(ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν)`
+
+The returned array has indices `W[τ13, τ24, τ′, τ12, τ34, τ]`. For SU(2),
+`wigner9ν` is evaluated from the ordinary Wigner 9j symbol with the corresponding
+dimension factor. The public `wigner9ν` wrapper is implemented only for SU(2);
+general SU(Nc) 9ν construction is available through `_9ν` and the table
+generators. DMRG runs with `Nc > 2` use precomputed tables.
+
+## SU(2) Correspondence
+
+For SU(2), the package row-length label ``\mu`` corresponds to spin ``j`` by
+
+```math
+\mu = 2j.
+```
+
+Thus the SU(2) fundamental representation is ``j = 1/2``, the adjoint
+representation is ``j = 1``, and the trivial representation is ``j = 0``.
+
+| SUNDMRG object | SU(2) angular-momentum object | Implementation |
+|:---------------|:------------------------------|:---------------|
+| `wigner3ν(ν1, ν2, ν)` | Exchange matrix between ``ν_1 \otimes ν_2`` and ``ν_2 \otimes ν_1`` coupling bases | `wigner9ν(ti, ν1, ν1, ν2, ti, ν2, ν2, ν1, ν)[1, 1, :, 1, 1, :]`, where `ti` is trivial |
+| `wigner6ν(ν1, ν2, ν12, ν3, ν, ν23)` | Racah-U coefficient | `racahU(...)` |
+| `wigner9ν(ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν)` | Wigner 9j with dimension normalization | `sqrt((μ12 + 1)(μ34 + 1)(μ13 + 1)(μ24 + 1)) * wigner9j(...)` |
+
+The SU(2) wrappers return arrays whose multiplicity dimensions are `1` for
+allowed couplings and `0` for forbidden couplings. The array shape is kept
+compatible with the SU(Nc) code path.
+
+## Coefficient Generation
+
+The table-generation pipeline separates expensive coefficient construction from
+DMRG execution:
+
+| Stage | Output file | Mathematical content | Implementation |
+|:------|:------------|:---------------------|:---------------|
+| `make_table3nu(Nc, widthmax)` | `table3nuhalf_SU$(Nc)_$(widthmax).jld2` | Selected half-table of 3ν exchange matrices for allowed sectors | `_3ν` |
+| `make_table4(Nc, widthmax)` | `table4half_SU$(Nc)_$(widthmax).jld2` | Selected half-table of 9ν slices for adjoint-adjoint interactions | `_9ν`-style SDC overlaps |
+| `make_table(Nc, widthmax)` | `table_SU$(Nc)_$(widthmax).jld2` | The six-table tuple consumed by DMRG | `table_9ν` |
+
+`make_table` also fills symmetry-related entries and derives the specialized
+tables needed by the DMRG kernels. The final `tables` object is therefore a tuple
+of six coefficient dictionaries rather than a raw dump of all 3ν, 6ν, and 9ν
+symbols.
+
+## DMRG Table Map
+
+The following table gives the one-to-one correspondence between each table slot,
+the mathematical coefficient it stores, the on-the-fly SU(2) helper, and the DMRG
+operation that consumes it.
+
+| Table slot | Key | Stored coefficient | SU(2) helper | DMRG use |
+|:-----------|:----|:-------------------|:-------------|:---------|
+| `tables[1]` | `(α1, β1, α2, β2)` | ``9ν(α_1,f,β_1; a,1,a; α_2,f,β_2)[:,1,1,1,1,:]`` | `on_the_fly_calc1` | Recouple an existing block tensor operator after adding a fundamental site. Used to build `BlockEnlarging`, then reused in Lanczos, measurements, and density-matrix mixing. |
+| `tables[2]` | `(α, β1, β2)` | ``6ν(α,f,β_1; a,β_2,f)[1,1,1,:]`` | `on_the_fly_calc2` | Build the spin tensor for the newly added site in `_build_spin_tensor`. |
+| `tables[3]` | `(α1, β, α2)` | ``9ν(α_1,f,β; a,a,1; α_2,f,β)[:,1,1,1,1,1]`` | `on_the_fly_calc3` | Add intra-block bond interactions to the enlarged block Hamiltonian. |
+| `tables[4]` | `(α1, β1, γ, α2, β2)` | ``9ν(α_1,β_1,γ; a,a,1; α_2,β_2,γ)[:,:,:,:,1,1]`` | `on_the_fly_calc4` | Build the superblock inter-block interaction term `H2`. |
+| `tables[5]` | `(αj, βl, αi, γ, βk)` | ``6ν(α_j,f,β_l; α_i,γ,β_k)[1,:,1,:] \, 3ν(α_i,f,β_k)[1,1]`` | `on_the_fly_calc5` | Transform the optimized wavefunction into the next-step initial guess in `eig_prediction`. |
+| `tables[6]` | `(α, β, γ)` | ``3ν(α,β,γ)`` | `on_the_fly_calc6` | Reverse the system/environment ordering of a wavefunction in `wavefunction_reverse`. |
+
+The letters ``α`` and ``β`` follow the local variable names used by each kernel,
+not one global convention across all six tables. In rows involving a one-site
+enlargement, ``α`` labels sectors before adding the fundamental site and ``β``
+labels sectors after the addition. In the superblock and wavefunction-transfer
+rows, the subscripts instead distinguish the coupled block sectors before and
+after adjoint or fundamental recoupling. The representation ``γ`` is the total
+sector carried by the relevant system-environment product.
+
+## On-The-Fly And Precomputed Modes
+
+At runtime, SU(2) runs set `on_the_fly = true`. Each DMRG kernel calls
+`on_the_fly_calc1` through `on_the_fly_calc6`, which evaluate the small Wigner or
+Racah coefficients as needed.
+
+For `Nc > 2`, `on_the_fly = false`. The user must provide both `widthmax` and the
+precomputed `tables` tuple. This keeps the DMRG run focused on linear algebra and
+table lookup, while the expensive SDC-based coefficient construction is performed
+ahead of time.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,10 @@ using SUNDMRG
     include("test_tables_small.jl")
     include("test_tables_ground_truth.jl")
     include("test_representation_theory_internal.jl")
+    include("test_representation_theory_definitions.jl")
     include("test_step_helpers.jl")
     include("test_lanczos_helpers.jl")
     include("test_tools_onthefly.jl")
+    include("test_wigner_racah_definitions.jl")
     include("test_run_dmrg.jl")
 end

--- a/test/test_representation_theory_definitions.jl
+++ b/test/test_representation_theory_definitions.jl
@@ -1,0 +1,139 @@
+using LinearAlgebra: I, dot
+using SUNRepresentations: directproduct, dim, weight
+
+function _test_young_rows(Nc, widthmax)
+    rows = NTuple{Nc, Int}[]
+
+    function extend!(prefix, max_row)
+        if length(prefix) == Nc - 1
+            push!(rows, Tuple(vcat(prefix, 0)))
+            return nothing
+        end
+        for row in 0 : max_row
+            extend!(vcat(prefix, row), row)
+        end
+        return nothing
+    end
+
+    for first_row in 0 : widthmax
+        extend!([first_row], first_row)
+    end
+
+    rows
+end
+
+function _test_hook_tableau_count(rows)
+    rows = filter(>(0), collect(rows))
+    isempty(rows) && return Int128(1)
+
+    hooks = Int[]
+    for i in eachindex(rows), j in 1 : rows[i]
+        below = count(k -> rows[k] >= j, i + 1 : length(rows))
+        push!(hooks, rows[i] - j + below + 1)
+    end
+
+    Int128(factorial(big(sum(rows))) ÷ prod(big.(hooks)))
+end
+
+function _test_weyl_dimension(rows)
+    λ = collect(rows)
+    Nc = length(λ)
+    result = 1 // 1
+    for i in 1 : Nc - 1, j in i + 1 : Nc
+        result *= (λ[i] - λ[j] + j - i) // (j - i)
+    end
+    @assert denominator(result) == 1
+    numerator(result)
+end
+
+function _test_normalized_product_weight(ν1, ν2, ν)
+    Nc = length(weight(ν1))
+    μ1, μ2, μ = map(collect ∘ weight, (ν1, ν2, ν))
+    f1, f2 = map(sum, (μ1, μ2))
+    μ .+= (f1 + f2 - sum(μ)) ÷ Nc
+    map(Tuple, (μ1, μ2, μ))
+end
+
+@testset "Irrep enumeration follows Young row-length definitions" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    for Nc in 2 : 5, widthmax in 0 : 3
+        actual = weight.(RT.irreplist(Nc, widthmax))
+        expected = _test_young_rows(Nc, widthmax)
+        @test actual == expected
+        @test length(actual) == binomial(widthmax + Nc - 1, Nc - 1)
+    end
+end
+
+@testset "Young diagram multiplicities follow the hook-length formula" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    for rows in (
+        Int[],
+        [1],
+        [2],
+        [1, 1],
+        [2, 1],
+        [3, 1],
+        [3, 2],
+        [2, 1, 1],
+        [3, 2, 1],
+    )
+        @test RT.multiplicity(rows) == _test_hook_tableau_count(rows)
+
+        if !isempty(rows)
+            V, E, _ = RT.SYTdiagram(rows)
+            B, _ = RT.bf(sum(rows), V, E, Int128)
+            @test B[1][1] == RT.multiplicity(rows)
+        end
+    end
+end
+
+@testset "SUNIrrep dimensions follow the Weyl dimension formula" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    for Nc in 2 : 5
+        for irrep in RT.irreplist(Nc, 3)
+            @test dim(irrep) == _test_weyl_dimension(weight(irrep))
+        end
+
+        @test dim(RT.trivialirrep(Val(Nc))) == 1
+        @test dim(RT.fundamentalirrep(Val(Nc))) == Nc
+        @test dim(RT.adjointirrep(Val(Nc))) == Nc ^ 2 - 1
+    end
+end
+
+@testset "Tensor-product multiplicities preserve dimensions" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    for Nc in 2 : 5
+        trivial = RT.trivialirrep(Val(Nc))
+        funda = RT.fundamentalirrep(Val(Nc))
+        adjoint = RT.adjointirrep(Val(Nc))
+        probes = (trivial, funda, adjoint)
+
+        for α in probes, β in probes
+            decomposition = directproduct(α, β)
+            @test sum(mult * dim(γ) for (γ, mult) in decomposition) == dim(α) * dim(β)
+            for (γ, mult) in decomposition
+                @test RT.outer_multiplicity(α, β, γ) == mult
+            end
+        end
+
+        OM = RT.OM_matrix(collect(probes), collect(probes), trivial)
+        @test OM == [RT.outer_multiplicity(α, β, trivial) for α in probes, β in probes]
+    end
+end
+
+@testset "Subduction coefficients form orthonormal outer-multiplicity bases" begin
+    RT = SUNDMRG.RepresentationTheory
+
+    adjoint = RT.adjointirrep(Val(3))
+    ν1, ν2, ν = _test_normalized_product_weight(adjoint, adjoint, adjoint)
+    vec1 = RT.sparsevec2(Int128[1], [1.0], RT.multiplicity(ν1))
+    vec2 = RT.sparsevec2(Int128[1], [1.0], RT.multiplicity(ν2))
+
+    coeffs = RT.SDC(ν1, ν2, ν, vec1, vec2)
+    @test length(coeffs) == RT.outer_multiplicity(adjoint, adjoint, adjoint)
+    @test [dot(coeffs[i], coeffs[j]) for i in eachindex(coeffs), j in eachindex(coeffs)] ≈ Matrix(I, length(coeffs), length(coeffs))
+end

--- a/test/test_wigner_racah_definitions.jl
+++ b/test/test_wigner_racah_definitions.jl
@@ -1,0 +1,92 @@
+using LinearAlgebra: dot
+using SUNRepresentations: weight
+
+function _test_one_sparsevec(ν)
+    SUNDMRG.sparsevec2(Int128[1], [1.0], SUNDMRG.multiplicity(ν))
+end
+
+function _test_weight_tuples_3(ν1, ν2, ν)
+    Nc = length(weight(ν1))
+    μ1, μ2, μ = map(collect ∘ weight, (ν1, ν2, ν))
+    f1, f2 = map(sum, (μ1, μ2))
+    μ .+= (f1 + f2 - sum(μ)) ÷ Nc
+    map(Tuple, (μ1, μ2, μ))
+end
+
+function _test_weight_tuples_6(ν1, ν2, ν12, ν3, ν, ν23)
+    Nc = length(weight(ν1))
+    μ1, μ2, μ12, μ3, μ, μ23 = map(collect ∘ weight, (ν1, ν2, ν12, ν3, ν, ν23))
+    f1, f2, f3 = map(sum, (μ1, μ2, μ3))
+    μ12 .+= (f1 + f2 - sum(μ12)) ÷ Nc
+    μ23 .+= (f2 + f3 - sum(μ23)) ÷ Nc
+    μ .+= (sum(μ12) + f3 - sum(μ)) ÷ Nc
+    map(Tuple, (μ1, μ2, μ12, μ3, μ, μ23))
+end
+
+function _test_weight_tuples_9(ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν)
+    Nc = length(weight(ν1))
+    μ1, μ2, μ12, μ3, μ4, μ34, μ13, μ24, μ = map(collect ∘ weight, (ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν))
+    f1, f2, f3, f4 = map(sum, (μ1, μ2, μ3, μ4))
+    μ12 .+= (f1 + f2 - sum(μ12)) ÷ Nc
+    μ34 .+= (f3 + f4 - sum(μ34)) ÷ Nc
+    μ13 .+= (f1 + f3 - sum(μ13)) ÷ Nc
+    μ24 .+= (f2 + f4 - sum(μ24)) ÷ Nc
+    μ .+= (sum(μ12) + sum(μ34) - sum(μ)) ÷ Nc
+    map(Tuple, (μ1, μ2, μ12, μ3, μ4, μ34, μ13, μ24, μ))
+end
+
+function _test_3ν_from_sdc(ν1, ν2, ν)
+    ν1, ν2, ν = _test_weight_tuples_3(ν1, ν2, ν)
+    vec1 = _test_one_sparsevec(ν1)
+    vec2 = _test_one_sparsevec(ν2)
+    right = SUNDMRG.SDC(ν1, ν2, ν, vec1, vec2; perm = true)
+    left = SUNDMRG.SDC(ν2, ν1, ν, vec1, vec2)
+    [dot(left[τ′], right[τ]) for τ′ in eachindex(left), τ in eachindex(right)]
+end
+
+function _test_6ν_from_sdc(ν1, ν2, ν12, ν3, ν, ν23)
+    ν1, ν2, ν12, ν3, ν, ν23 = _test_weight_tuples_6(ν1, ν2, ν12, ν3, ν, ν23)
+    vec1 = _test_one_sparsevec(ν1)
+    vec2 = _test_one_sparsevec(ν2)
+    vec3 = _test_one_sparsevec(ν3)
+    vec12 = SUNDMRG.SDC(ν1, ν2, ν12, vec1, vec2)
+    right = [SUNDMRG.SDC(ν12, ν3, ν, vec12[τ12], vec3) for τ12 in eachindex(vec12)]
+    vec23 = SUNDMRG.SDC(ν2, ν3, ν23, vec2, vec3)
+    left = [SUNDMRG.SDC(ν1, ν23, ν, vec1, vec23[τ23]) for τ23 in eachindex(vec23)]
+    [dot(left[τ23][τ′], right[τ12][τ]) for τ23 in eachindex(vec23), τ′ in eachindex(left[1]), τ12 in eachindex(vec12), τ in eachindex(right[1])]
+end
+
+function _test_9ν_from_sdc(ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν; perm = true)
+    ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν = _test_weight_tuples_9(ν1, ν2, ν12, ν3, ν4, ν34, ν13, ν24, ν)
+    N1 = isempty(ν1) ? 0 : sum(ν1)
+    N4 = isempty(ν4) ? 0 : sum(ν4)
+    vec1 = _test_one_sparsevec(ν1)
+    vec2 = _test_one_sparsevec(ν2)
+    vec3 = _test_one_sparsevec(ν3)
+    vec4 = _test_one_sparsevec(ν4)
+    vec12 = SUNDMRG.SDC(ν1, ν2, ν12, vec1, vec2)
+    vec34 = SUNDMRG.SDC(ν3, ν4, ν34, vec3, vec4)
+    right = [SUNDMRG.SDC(ν12, ν34, ν, vec12[τ12], vec34[τ34]; perm = perm, f1 = N1, f4 = N4) for τ12 in eachindex(vec12), τ34 in eachindex(vec34)]
+    vec13 = SUNDMRG.SDC(ν1, ν3, ν13, vec1, vec3)
+    vec24 = SUNDMRG.SDC(ν2, ν4, ν24, vec2, vec4)
+    left = [SUNDMRG.SDC(ν13, ν24, ν, vec13[τ13], vec24[τ24]) for τ13 in eachindex(vec13), τ24 in eachindex(vec24)]
+    [dot(left[τ13, τ24][τ′], right[τ12, τ34][τ]) for τ13 in eachindex(vec13), τ24 in eachindex(vec24), τ′ in eachindex(left[1, 1]), τ12 in eachindex(vec12), τ34 in eachindex(vec34), τ in eachindex(right[1, 1])]
+end
+
+@testset "Wigner/Racah coefficients follow SDC recoupling definitions" begin
+    trivial = SUNDMRG.trivialirrep(Val(2))
+    funda = SUNDMRG.fundamentalirrep(Val(2))
+    adjoint = SUNDMRG.adjointirrep(Val(2))
+
+    @test SUNDMRG._3ν(funda, funda, adjoint) ≈ _test_3ν_from_sdc(funda, funda, adjoint)
+    @test SUNDMRG._6ν(funda, funda, adjoint, funda, funda, adjoint) ≈
+          _test_6ν_from_sdc(funda, funda, adjoint, funda, funda, adjoint)
+
+    nineν_case = (trivial, funda, funda, adjoint, trivial, adjoint, adjoint, funda, funda)
+    with_p23 = _test_9ν_from_sdc(nineν_case...)
+    without_p23 = _test_9ν_from_sdc(nineν_case...; perm = false)
+
+    @test SUNDMRG._9ν(nineν_case...) ≈ with_p23
+    @test !(SUNDMRG._9ν(nineν_case...) ≈ without_p23)
+    @test only(without_p23) ≈ 0.5
+end


### PR DESCRIPTION
## Summary
- bump package version to v1.5.6 and update the changelog
- add Wigner/Racah coefficient documentation mapping 3ν, 6ν, and 9ν definitions to implementation functions and DMRG table slots
- add representation-theory definition tests, including SDC recoupling checks for _3ν, _6ν, and _9ν with the formal P23 permutation

## Checks
- `julia --project=. -e 'using Test, SUNDMRG; include("test/test_wigner_racah_definitions.jl")'`
- `julia --project=. -e 'using Test, SUNDMRG; include("test/test_representation_theory_definitions.jl")'`
- `julia --project=. test/runtests.jl`
- `julia --project=docs docs/make.jl`